### PR TITLE
add support for trace function

### DIFF
--- a/examples/simple_callable_trace.py
+++ b/examples/simple_callable_trace.py
@@ -1,0 +1,20 @@
+import paddle
+
+from paddlefx import symbolic_trace
+
+
+def net(x, y):
+    x = x * x
+    x = x + y
+    x = paddle.add(x=x, y=x)
+    return paddle.nn.functional.relu(x=x)
+
+
+# tracing a paddle layer
+graph = symbolic_trace(net)
+
+print("python IR:")
+graph.print_tabular()
+print("python code generated:")
+src, _ = graph.python_code(root_module='self')
+print(src)


### PR DESCRIPTION
#2 的一个 TODO，尝试简单支持了下 Callable（仅支持函数，不支持显式重载 `__call__` 的 Callable object，试了下 torch.fx 也是不支持的），keyword args 还没支持～

```
> python examples/simple_callable_trace.py

python IR:
opcode         name    target                          args      kwargs
-------------  ------  ------------------------------  --------  --------------------
placeholder    x       x                               ()        {}
placeholder    y       y                               ()        {}
call_function  mul     <built-in function mul>         (x, x)    {}
call_function  add     <built-in function add>         (mul, y)  {}
call_function  add     <function add at 0x13fc54430>   ()        {'x': add, 'y': add}
call_function  relu    <function relu at 0x16c09b2e0>  ()        {'x': add}
output         output  output                          (relu,)   {}
python code generated:
mul = x * x
add = mul + y
add = paddle.tensor.math.add(x = add, y = add)
relu = paddle.nn.functional.activation.relu(x = add)
return (relu,)
```