### PR TITLE
add python3.9/3.10 to ci environment

### DIFF
--- a/.github/workflows/codestyle-check.yml
+++ b/.github/workflows/codestyle-check.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   code-style-check:
     runs-on: ubuntu-latest
-    name: CodeStyle Check
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+    name: CodeStyle Check (Python ${{ matrix.python-version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -17,8 +20,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          # Currently, we only support Python 3.8
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/codestyle-check.yml
+++ b/.github/workflows/codestyle-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     name: CodeStyle Check (Python ${{ matrix.python-version }})
     steps:
       - name: Checkout

--- a/.github/workflows/codestyle-check.yml
+++ b/.github/workflows/codestyle-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10']
     name: CodeStyle Check (Python ${{ matrix.python-version }})
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     name: Run Unittests and Examples (Python ${{ matrix.python-version }})
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10']
     name: Run Unittests and Examples (Python ${{ matrix.python-version }})
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   Test:
     runs-on: ubuntu-latest
-    name: Run unit tests and examples
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+    name: Run Unittests and Examples (Python ${{ matrix.python-version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -17,8 +20,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          # Currently, we only support Python 3.8
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
由于 Paddle 尚不支持 Python 3.11，所以在安装依赖时候就会挂掉，因此先不加 3.11～