### PR TITLE
interpreter added, and an example of using paddlefx to profile resnet

### DIFF
--- a/examples/fx_profiling.py
+++ b/examples/fx_profiling.py
@@ -1,0 +1,105 @@
+# this is from: https://github.com/pytorch/tutorials/blob/main/intermediate_source/fx_profiling_tutorial.py
+
+import statistics
+import time
+
+from typing import Any, Dict, List
+
+import paddle
+import paddle.nn
+import tabulate
+
+from paddle.vision.models import resnet18
+
+import paddlefx
+
+from paddlefx import Interpreter, symbolic_trace
+
+net = resnet18()
+example_input = paddle.rand([8, 3, 224, 224])
+
+# traced_rn18 = symbolic_trace(net)
+# traced_rn18.graph.print_tabular()
+
+
+class ProfilingInterpreter(Interpreter):
+    def __init__(self, mod: paddle.nn.Layer):
+        gm = symbolic_trace(mod)
+        super().__init__(gm)
+
+        self.total_runtime_sec: List[float] = []
+        self.runtimes_sec: Dict[paddlefx.Node, List[float]] = {}
+
+    def run(self, *args) -> Any:
+        # Record the time we started running the model
+        t_start = time.time()
+        # Run the model by delegating back into Interpreter.run()
+        return_val = super().run(*args)
+        # Record the time we finished running the model
+        t_end = time.time()
+        # Store the total elapsed time this model execution took in the
+        # ProfilingInterpreter
+        self.total_runtime_sec.append(t_end - t_start)
+        return return_val
+
+    def run_node(self, n: paddlefx.Node) -> Any:
+        # Record the time we started running the op
+        t_start = time.time()
+        # Run the op by delegating back into Interpreter.run_node()
+        return_val = super().run_node(n)
+        # Record the time we finished running the op
+        t_end = time.time()
+        # If we don't have an entry for this node in our runtimes_sec
+        # data structure, add one with an empty list value.
+        self.runtimes_sec.setdefault(n, [])
+        # Record the total elapsed time for this single invocation
+        # in the runtimes_sec data structure
+        self.runtimes_sec[n].append(t_end - t_start)
+        return return_val
+
+    ######################################################################
+    # Finally, we are going to define a method (one which doesn't override
+    # any ``Interpreter`` method) that provides us a nice, organized view of
+    # the data we have collected.
+
+    def summary(self, should_sort: bool = False) -> str:
+        # Build up a list of summary information for each node
+        node_summaries: List[List[Any]] = []
+        # Calculate the mean runtime for the whole network. Because the
+        # network may have been called multiple times during profiling,
+        # we need to summarize the runtimes. We choose to use the
+        # arithmetic mean for this.
+        mean_total_runtime = statistics.mean(self.total_runtime_sec)
+
+        # For each node, record summary statistics
+        for node, runtimes in self.runtimes_sec.items():
+            # Similarly, compute the mean runtime for ``node``
+            mean_runtime = statistics.mean(runtimes)
+            # For easier understanding, we also compute the percentage
+            # time each node took with respect to the whole network.
+            pct_total = mean_runtime / mean_total_runtime * 100
+            # Record the node's type, name of the node, mean runtime, and
+            # percent runtim
+            node_summaries.append([node.op, str(node), mean_runtime, pct_total])
+
+        # One of the most important questions to answer when doing performance
+        # profiling is "Which op(s) took the longest?". We can make this easy
+        # to see by providing sorting functionality in our summary view
+        if should_sort:
+            node_summaries.sort(key=lambda s: s[2], reverse=True)
+
+        # Use the ``tabulate`` library to create a well-formatted table
+        # presenting our summary information
+        headers: List[str] = [
+            'Op type',
+            'Op',
+            'Average runtime (s)',
+            'Pct total runtime',
+        ]
+        return tabulate.tabulate(node_summaries, headers=headers)
+
+
+interp = ProfilingInterpreter(net)
+for _ in range(10):
+    interp.run(example_input)
+print(interp.summary(True))

--- a/src/paddlefx/__init__.py
+++ b/src/paddlefx/__init__.py
@@ -7,6 +7,7 @@ except ImportError:
 
 
 from .graph import Graph
+from .interpreter import Interpreter as Interpreter
 from .node import Node
 from .proxy import Proxy
 from .symbolic_trace import Tracer, symbolic_trace

--- a/src/paddlefx/interpreter.py
+++ b/src/paddlefx/interpreter.py
@@ -1,0 +1,237 @@
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+
+from .graph_layer import GraphLayer
+from .node import Node, map_arg
+
+__all__ = ['Interpreter']
+
+
+class Interpreter:
+    def __init__(self, module: GraphLayer):
+        assert isinstance(module, GraphLayer)
+        self.module = module
+        self.env: Dict[Node, Any] = {}
+        self.name = "Interpreter"
+
+    def run(self, *args) -> Any:
+        """Run `module` via interpretation and return the result.
+
+        Args:
+            *args: The arguments to the Module to run, in positional order
+
+        Returns:
+            Any: The value returned from executing the Module
+        """
+
+        self.args_iter: Iterator[Any] = iter(args)
+
+        for node in self.module.graph.nodes:
+            try:
+                self.env[node] = self.run_node(node)
+            except Exception as e:
+                msg = f"While executing {node}"
+                msg = '{}\n\n{}'.format(e.args[0], msg) if e.args else str(msg)
+                e.args = (msg,) + e.args[1:]
+                if isinstance(e, KeyError):
+                    raise RuntimeError(*e.args) from e
+                raise
+
+            if node.op == 'output':
+                output_val = self.env[node]
+                return output_val
+
+    def run_node(self, n: Node) -> Any:
+        """Run a specific node ``n`` and return the result.
+        Calls into placeholder, get_attr, call_function,
+        call_method, call_module, or output depending
+        on ``node.op``
+
+        Args:
+            n (Node): The Node to execute
+
+        Returns:
+            Any: The result of executing ``n``
+        """
+        args, kwargs = self.fetch_args_kwargs_from_env(n)
+        assert isinstance(args, tuple)
+        assert isinstance(kwargs, dict)
+        return getattr(self, n.op)(n.target, args, kwargs)
+
+    # Main Node running APIs
+    def placeholder(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+        """Execute a ``placeholder`` node. Note that this is stateful:
+        ``Interpreter`` maintains an internal iterator over
+        arguments passed to ``run`` and this method returns
+        next() on that iterator.
+
+        Args:
+            target (Target): The call target for this node.
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
+
+        Returns:
+            Any: The argument value that was retrieved.
+        """
+        assert isinstance(target, str)
+        if target.startswith('*'):
+            # For a starred parameter e.g. `*args`, retrieve all
+            # remaining values from the args list.
+            return list(self.args_iter)
+        else:
+            try:
+                return next(self.args_iter)
+            except StopIteration as si:
+                if len(args) > 0:
+                    return args[0]
+                else:
+                    raise RuntimeError(
+                        f'Expected positional argument for parameter {target}, but one was not passed in!'
+                    ) from si
+
+    def get_attr(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+        """Execute a ``get_attr`` node. Will retrieve an attribute
+        value from the ``Module`` hierarchy of ``self.module``.
+
+        Args:
+            target (Target): The call target for this node.
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
+
+        Return:
+            Any: The value of the attribute that was retrieved
+        """
+        assert isinstance(target, str)
+        return self.fetch_attr(target)
+
+    def call_function(
+        self, target: 'Target', args: Tuple, kwargs: Dict[str, Any]
+    ) -> Any:
+        """Execute a ``call_function`` node and return the result.
+
+        Args:
+            target (Target): The call target for this node. See
+                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                details on semantics
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
+
+        Return
+            Any: The value returned by the function invocation
+        """
+        assert not isinstance(target, str)
+
+        # Execute the function and return the result
+        return target(*args, **kwargs)
+
+    def call_method(self, target: 'Target', args: Tuple, kwargs: Dict[str, Any]) -> Any:
+        """Execute a ``call_method`` node and return the result.
+
+        Args:
+            target (Target): The call target for this node. See
+                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                details on semantics
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
+
+        Return
+            Any: The value returned by the method invocation
+        """
+        # args[0] is the `self` object for this method call
+        self_obj, *args_tail = args
+
+        # Execute the method and return the result
+        assert isinstance(target, str)
+        return getattr(self_obj, target)(*args_tail, **kwargs)
+
+    def call_module(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+        """Execute a ``call_module`` node and return the result.
+
+        Args:
+            target (Target): The call target for this node. See
+                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                details on semantics
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
+
+        Return
+            Any: The value returned by the module invocation
+        """
+        # Retrieve executed args and kwargs values from the environment
+
+        # Execute the method and return the result
+        assert isinstance(target, str)
+        submod = self.fetch_attr(target)
+
+        return submod(*args, **kwargs)
+
+    def output(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+        """Execute an ``output`` node. This really just retrieves
+        the value referenced by the ``output`` node and returns it.
+
+        Args:
+            target (Target): The call target for this node. See
+                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
+                details on semantics
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
+
+        Return:
+            Any: The return value referenced by the output node
+        """
+        return args[0]
+
+    # Helper methods
+    def fetch_attr(self, target: str):
+        """Fetch an attribute from the ``Module`` hierarchy of ``self.module``.
+
+        Args:
+            target (str): The fully-qualified name of the attribute to fetch
+
+        Return:
+            Any: The value of the attribute.
+        """
+        target_atoms = target.split('.')
+        attr_itr = self.module
+        for i, atom in enumerate(target_atoms):
+            if not hasattr(attr_itr, atom):
+                raise RuntimeError(
+                    f"Node referenced nonexistent target {'.'.join(target_atoms[:i])}"
+                )
+            attr_itr = getattr(attr_itr, atom)
+        return attr_itr
+
+    def fetch_args_kwargs_from_env(self, n: Node) -> Tuple[Tuple, Dict]:
+        """Fetch the concrete values of ``args`` and ``kwargs`` of node ``n``
+        from the current execution environment.
+
+        Args:
+            n (Node): The node for which ``args`` and ``kwargs`` should be fetched.
+
+        Return:
+            Tuple[Tuple, Dict]: ``args`` and ``kwargs`` with concrete values for ``n``.
+        """
+        args = self.map_nodes_to_values(n.args, n)
+        assert isinstance(args, tuple)
+        kwargs = self.map_nodes_to_values(n.kwargs, n)
+        assert isinstance(kwargs, dict)
+        return args, kwargs
+
+    def map_nodes_to_values(self, args, n: Node) -> Any:
+        """Recursively descend through ``args`` and look up the concrete value
+        for each ``Node`` in the current execution environment.
+
+        Args:
+            args (Argument): Data structure within which to look up concrete values
+
+            n (Node): Node to which ``args`` belongs. This is only used for error reporting.
+        """
+
+        def load_arg(n_arg: Node) -> Any:
+            if n_arg not in self.env:
+                raise RuntimeError(
+                    f'Node {n} referenced nonexistent value {n_arg}! Run Graph.lint() '
+                    f'to diagnose such issues'
+                )
+            return self.env[n_arg]
+
+        return map_arg(args, load_arg)

--- a/src/paddlefx/interpreter.py
+++ b/src/paddlefx/interpreter.py
@@ -103,15 +103,11 @@ class Interpreter:
         assert isinstance(target, str)
         return self.fetch_attr(target)
 
-    def call_function(
-        self, target: 'Target', args: Tuple, kwargs: Dict[str, Any]
-    ) -> Any:
+    def call_function(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
         """Execute a ``call_function`` node and return the result.
 
         Args:
-            target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
-                details on semantics
+            target (Target): The call target for this node.
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
 
@@ -123,13 +119,11 @@ class Interpreter:
         # Execute the function and return the result
         return target(*args, **kwargs)
 
-    def call_method(self, target: 'Target', args: Tuple, kwargs: Dict[str, Any]) -> Any:
+    def call_method(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
         """Execute a ``call_method`` node and return the result.
 
         Args:
-            target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
-                details on semantics
+            target (Target): The call target for this node.
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
 
@@ -147,9 +141,7 @@ class Interpreter:
         """Execute a ``call_module`` node and return the result.
 
         Args:
-            target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
-                details on semantics
+            target (Target): The call target for this node.
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
 
@@ -169,9 +161,7 @@ class Interpreter:
         the value referenced by the ``output`` node and returns it.
 
         Args:
-            target (Target): The call target for this node. See
-                `Node <https://pytorch.org/docs/master/fx.html#torch.fx.Node>`__ for
-                details on semantics
+            target (Target): The call target for this node.
             args (Tuple): Tuple of positional args for this invocation
             kwargs (Dict): Dict of keyword arguments for this invocation
 

--- a/src/paddlefx/node.py
+++ b/src/paddlefx/node.py
@@ -43,3 +43,12 @@ def map_aggregate(a, fn):
         )
     else:
         return fn(a)
+
+
+def map_arg(a: Any, fn: Callable[[Node], Any]) -> Any:
+    """Apply fn to each Node appearing arg.
+
+    arg may be a list, tuple, slice, or dict with string keys.
+    """
+    assert callable(fn), "torch.fx.map_arg(a, fn): fn must be a callable"
+    return map_aggregate(a, lambda x: fn(x) if isinstance(x, Node) else x)

--- a/src/paddlefx/node.py
+++ b/src/paddlefx/node.py
@@ -50,5 +50,5 @@ def map_arg(a: Any, fn: Callable[[Node], Any]) -> Any:
 
     arg may be a list, tuple, slice, or dict with string keys.
     """
-    assert callable(fn), "torch.fx.map_arg(a, fn): fn must be a callable"
+    assert callable(fn), "fn must be a callable"
     return map_aggregate(a, lambda x: fn(x) if isinstance(x, Node) else x)


### PR DESCRIPTION
a typical use case of paddlefx is using it to profile an existing model, without copy/edit the original model codes.

this use case is shown in examples/fx_profiling.py