### PR TITLE
cover symbolic_trace by tracing several vision models in tests

### DIFF
--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -108,7 +108,7 @@ class Graph:
         return n
 
     def output(self, result):
-        return self.create_node(op='output', target='output', args=(result,))
+        return self.create_node(op='output', target='output', args=result)
 
     def _name(self, op):
         if hasattr(op, '__name__'):

--- a/src/paddlefx/interpreter.py
+++ b/src/paddlefx/interpreter.py
@@ -53,7 +53,7 @@ class Interpreter:
             Any: The result of executing ``n``
         """
         args, kwargs = self.fetch_args_kwargs_from_env(n)
-        assert isinstance(args, tuple)
+        # assert isinstance(args, tuple)
         assert isinstance(kwargs, dict)
         return getattr(self, n.op)(n.target, args, kwargs)
 
@@ -201,7 +201,7 @@ class Interpreter:
             Tuple[Tuple, Dict]: ``args`` and ``kwargs`` with concrete values for ``n``.
         """
         args = self.map_nodes_to_values(n.args, n)
-        assert isinstance(args, tuple)
+        #        assert isinstance(args, tuple)
         kwargs = self.map_nodes_to_values(n.kwargs, n)
         assert isinstance(kwargs, dict)
         return args, kwargs

--- a/src/paddlefx/proxy.py
+++ b/src/paddlefx/proxy.py
@@ -96,7 +96,7 @@ for method in magic_methods:
         def impl(*args, **kwargs):
             tracer = args[0].tracer
             target = getattr(operator, method)
-            return _create_proxy(tracer, 'call_function', target, args, kwargs, method)
+            return _create_proxy(tracer, 'call_function', target, args, kwargs)
 
         impl.__name__ = method
         as_magic = f'__{method}__'

--- a/src/paddlefx/symbolic_trace.py
+++ b/src/paddlefx/symbolic_trace.py
@@ -152,7 +152,7 @@ def _create_wrapped_func(orig_fn):
         proxy = _find_proxy(args, kwargs)
         if proxy is not None:
             return_proxy = _create_proxy(
-                proxy.tracer, 'call_function', orig_fn, args, kwargs, orig_fn.__name__
+                proxy.tracer, 'call_function', orig_fn, args, kwargs
             )
             return return_proxy
         return orig_fn(*args, **kwargs)

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,54 @@
+import unittest
+
+import paddle
+
+import paddlefx
+
+
+class TestFx(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.models_to_track = [
+            (paddle.vision.models.resnet18(), paddle.randn([2, 3, 224, 224])),
+            (paddle.vision.models.alexnet(), paddle.randn([2, 3, 224, 224])),
+            # DenseNet will failed on symbolic_trace, since it calls into _C_ops
+            #            (paddle.vision.models.densenet121(), paddle.randn([2, 3, 224, 224])),
+            (paddle.vision.models.googlenet(), paddle.randn([2, 3, 224, 224])),
+            (paddle.vision.models.inception_v3(), paddle.randn([2, 3, 299, 299])),
+            (paddle.vision.models.mobilenet_v2(), paddle.randn([2, 3, 224, 224])),
+        ]
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_trace(self):
+        for model, input_example in self.models_to_track:
+            traced_model = paddlefx.symbolic_trace(model)
+            paddle.seed(1234)
+            orig_output = model(input_example)
+            paddle.seed(1234)
+            traced_output = traced_model(input_example)
+
+            # some nets, e.g.: googlenet, return a list of tensors
+            orig_ret_list = (
+                list(orig_output)
+                if isinstance(orig_output, (list, tuple))
+                else [orig_output]
+            )
+            traced_ret_list = (
+                [*traced_output]
+                if isinstance(traced_output, (list, tuple))
+                else [traced_output]
+            )
+
+            self.assertEqual(
+                len(orig_ret_list),
+                len(traced_ret_list),
+                f"model: {type(model).__name__} failed",
+            )
+
+            for i, o in enumerate(traced_ret_list):
+                self.assertTrue(
+                    paddle.allclose(orig_ret_list[i], traced_ret_list[i]),
+                    f"model: {type(model).__name__} failed",
+                )

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -11,11 +11,16 @@ class TestFx(unittest.TestCase):
         self.models_to_track = [
             (paddle.vision.models.resnet18(), paddle.randn([2, 3, 224, 224])),
             (paddle.vision.models.alexnet(), paddle.randn([2, 3, 224, 224])),
-            # DenseNet will failed on symbolic_trace, since it calls into _C_ops
-            #            (paddle.vision.models.densenet121(), paddle.randn([2, 3, 224, 224])),
+            # DenseNet will fail, since it calls into _C_ops
+            # (paddle.vision.models.densenet121(), paddle.randn([2, 3, 224, 224])),
             (paddle.vision.models.googlenet(), paddle.randn([2, 3, 224, 224])),
             (paddle.vision.models.inception_v3(), paddle.randn([2, 3, 299, 299])),
             (paddle.vision.models.mobilenet_v2(), paddle.randn([2, 3, 224, 224])),
+            # shufflenet will fail, since it calls into `x.shape[0:4]`
+            # (paddle.vision.models.shufflenet_v2_swish(), paddle.randn([2, 3, 224, 224])),
+            (paddle.vision.models.squeezenet1_0(), paddle.randn([2, 3, 224, 224])),
+            (paddle.vision.models.vgg11(), paddle.randn([2, 3, 224, 224])),
+            (paddle.vision.models.wide_resnet101_2(), paddle.randn([2, 3, 224, 224])),
         ]
 
     def tearDown(self):
@@ -23,6 +28,7 @@ class TestFx(unittest.TestCase):
 
     def test_trace(self):
         for model, input_example in self.models_to_track:
+            print(f"tracing model: {type(model).__name__}")
             traced_model = paddlefx.symbolic_trace(model)
             paddle.seed(1234)
             orig_output = model(input_example)


### PR DESCRIPTION
selected 10 vision models to trace, 8 of them succeed.
2 of them failed because of

- failed on DenseNet, since it calls into `_C_ops`.
- failed on ShuffleNet, since it calls into `x.shape[0:4]`