### PR TITLE
fix failure to trace densenet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ known_first_party = ["paddlefx"]
 minversion = "7.0.0"
 pythonpath = "tests"
 testpaths = ["tests"]
+filterwarnings = [
+    # Ignore warnings raised by paddlepaddle 2.4
+    "ignore::DeprecationWarning",
+]
 
 [tool.setuptools_scm]
 write_to = "src/paddlefx/_version.py"

--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -142,6 +142,8 @@ class Graph:
         for node in self.nodes:
             if node.op == 'placeholder':
                 free_vars.append(node.target)
+                if node.target != node.name:
+                    body.append(f'{node.name} = {node.target}\n')
                 continue
             elif node.op == 'call_method':
                 body.append(

--- a/src/paddlefx/symbolic_trace.py
+++ b/src/paddlefx/symbolic_trace.py
@@ -43,7 +43,7 @@ def _is_leaf_module(m) -> bool:
     return (
         m.__module__.startswith("paddle.nn")
         # `paddle.fluid.dygraph.nn` has removed in paddlepaddle 2.5.0 (develop),
-        # but still keep it for compatibility with paddlepaddle<=2.4
+        # but still keep it for compatibility with paddlepaddle <= 2.4
         or m.__module__.startswith("paddle.fluid.dygraph.nn")
         and not isinstance(m, paddle.nn.Sequential)
     )

--- a/src/paddlefx/symbolic_trace.py
+++ b/src/paddlefx/symbolic_trace.py
@@ -40,8 +40,12 @@ def _find_module(root, m):
 
 
 def _is_leaf_module(m) -> bool:
-    return m.__module__.startswith("paddle.nn") and not isinstance(
-        m, paddle.nn.Sequential
+    return (
+        m.__module__.startswith("paddle.nn")
+        # `paddle.fluid.dygraph.nn` has removed in paddlepaddle 2.5.0 (develop),
+        # but still keep it for compatibility with paddlepaddle<=2.4
+        or m.__module__.startswith("paddle.fluid.dygraph.nn")
+        and not isinstance(m, paddle.nn.Sequential)
     )
 
 

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -11,8 +11,7 @@ class TestFx(unittest.TestCase):
         self.models_to_track = [
             (paddle.vision.models.resnet18(), paddle.randn([2, 3, 224, 224])),
             (paddle.vision.models.alexnet(), paddle.randn([2, 3, 224, 224])),
-            # DenseNet will fail, since it calls into _C_ops
-            # (paddle.vision.models.densenet121(), paddle.randn([2, 3, 224, 224])),
+            (paddle.vision.models.densenet121(), paddle.randn([2, 3, 224, 224])),
             (paddle.vision.models.googlenet(), paddle.randn([2, 3, 224, 224])),
             (paddle.vision.models.inception_v3(), paddle.randn([2, 3, 299, 299])),
             (paddle.vision.models.mobilenet_v2(), paddle.randn([2, 3, 224, 224])),


### PR DESCRIPTION
修复 #22 提及的：

> failed on DenseNet, since it calls into `_C_ops`.

这里是因为 BatchNorm 在 PaddlePaddle 2.4 还在 `paddle.fluid.dygraph.nn`，因此之前（#15）根据判断模块是否在 `paddle.nn` 下来判断是否是一个 paddle API 在 2.4 下是不完善的（但在 develop 是没问题的，因为已经全部移出 fluid 了），所以原来这里直接 trace 了这个 API，而不是直接跳过，导致调用内部的 `_C_ops`

另外在 codegen 时期 target 和 name 不一致的时候加了一个赋值语句，以确保参数存在