### PR TITLE
fix failure to trace shufflenet_v2

### DIFF
--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -1,4 +1,7 @@
 import builtins
+import keyword
+
+from typing import Any
 
 import paddle
 import paddle.nn
@@ -22,6 +25,18 @@ def _qualified_name(func):
     name = func.__name__
     module = _find_module_of_method(func)
     return f'{module}.{name}'
+
+
+def _is_illegal_name(name: str, obj: Any) -> bool:
+    # 1. keywords are never allowed as names.
+    if name in keyword.kwlist:
+        return True
+
+    # 2. Can't shadow a builtin name, unless you *are* that builtin.
+    if name in builtins.__dict__:
+        return obj is not builtins.__dict__[name]
+
+    return False
 
 
 def _find_module_of_method(orig_method):
@@ -96,9 +111,12 @@ class Graph:
         kwargs = {} if kwargs is None else kwargs
         self._mark_uses(args)
         self._mark_uses(kwargs)
+        name = name if name is not None else self._name(target or op)
+        if name[0].isdigit():
+            name = f'_{name}'
         n = Node(
             self,
-            name if name is not None else self._name(target or op),
+            name,
             op,
             target,
             args,
@@ -125,6 +143,7 @@ class Graph:
                 not hasattr(paddle, op)
                 and not hasattr(paddle.nn.functional, op)
                 and not hasattr(paddle.nn, op)
+                and not _is_illegal_name(op, None)
             ):
                 return op
         i = self._used_names[op] = self._used_names[op] + 1

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -15,8 +15,10 @@ class TestFx(unittest.TestCase):
             (paddle.vision.models.googlenet(), paddle.randn([2, 3, 224, 224])),
             (paddle.vision.models.inception_v3(), paddle.randn([2, 3, 299, 299])),
             (paddle.vision.models.mobilenet_v2(), paddle.randn([2, 3, 224, 224])),
-            # shufflenet will fail, since it calls into `x.shape[0:4]`
-            # (paddle.vision.models.shufflenet_v2_swish(), paddle.randn([2, 3, 224, 224])),
+            (
+                paddle.vision.models.shufflenet_v2_swish(),
+                paddle.randn([2, 3, 224, 224]),
+            ),
             (paddle.vision.models.squeezenet1_0(), paddle.randn([2, 3, 224, 224])),
             (paddle.vision.models.vgg11(), paddle.randn([2, 3, 224, 224])),
             (paddle.vision.models.wide_resnet101_2(), paddle.randn([2, 3, 224, 224])),


### PR DESCRIPTION
修复 #22 提及的：

> failed on ShuffleNet, since it calls into `x.shape[0:4]`

10 个模型均可跑通啦～