### PR TITLE
add `from __future__ import annotations` to all files

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,6 +1,8 @@
 # ------------------------------------------------
 # Options affecting comment reflow and formatting.
 # ------------------------------------------------
+from __future__ import annotations
+
 with section("markup"):
     # enable comment markup parsing and reflow
     enable_markup = False

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
           - "--remove-duplicate-keys"
           - "--remove-unused-variables"
           - "--remove-all-unused-imports"
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.254
+    hooks:
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix, --no-cache]
   - repo: https://github.com/asottile/yesqa
     rev: v1.4.0
     hooks:

--- a/examples/fx_profiling.py
+++ b/examples/fx_profiling.py
@@ -1,5 +1,7 @@
 # this is from: https://github.com/pytorch/tutorials/blob/main/intermediate_source/fx_profiling_tutorial.py
 
+from __future__ import annotations
+
 import statistics
 import time
 

--- a/examples/fx_profiling.py
+++ b/examples/fx_profiling.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import statistics
 import time
 
-from typing import Any, Dict, List
+from typing import Any
 
 import paddle
 import paddle.nn
@@ -29,8 +29,8 @@ class ProfilingInterpreter(Interpreter):
         gm = symbolic_trace(mod)
         super().__init__(gm)
 
-        self.total_runtime_sec: List[float] = []
-        self.runtimes_sec: Dict[paddlefx.Node, List[float]] = {}
+        self.total_runtime_sec: list[float] = []
+        self.runtimes_sec: dict[paddlefx.Node, list[float]] = {}
 
     def run(self, *args) -> Any:
         # Record the time we started running the model
@@ -66,7 +66,7 @@ class ProfilingInterpreter(Interpreter):
 
     def summary(self, should_sort: bool = False) -> str:
         # Build up a list of summary information for each node
-        node_summaries: List[List[Any]] = []
+        node_summaries: list[list[Any]] = []
         # Calculate the mean runtime for the whole network. Because the
         # network may have been called multiple times during profiling,
         # we need to summarize the runtimes. We choose to use the
@@ -92,7 +92,7 @@ class ProfilingInterpreter(Interpreter):
 
         # Use the ``tabulate`` library to create a well-formatted table
         # presenting our summary information
-        headers: List[str] = [
+        headers: list[str] = [
             'Op type',
             'Op',
             'Average runtime (s)',

--- a/examples/graph_editing.py
+++ b/examples/graph_editing.py
@@ -1,0 +1,28 @@
+import paddle
+
+from paddlefx import symbolic_trace
+
+
+def net(x, y):
+    return x + y
+
+
+traced_layer = symbolic_trace(net)
+graph = traced_layer.graph
+
+print("Before editing:")
+graph.print_tabular()
+
+for node in graph.nodes:
+    if node.op == 'call_function':
+        break
+
+with graph.inserting_after(node):
+    new_node = graph.create_node(
+        node.op, paddle.add, args=(node.args[0], node.args[0]), kwargs={}
+    )
+    node.replace_all_uses_with(new_node)
+graph.erase_node(node)
+
+print("After editing:")
+graph.print_tabular()

--- a/examples/graph_editing.py
+++ b/examples/graph_editing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import paddle
 
 from paddlefx import symbolic_trace

--- a/examples/resnet_trace.py
+++ b/examples/resnet_trace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import paddle
 import paddle.nn
 

--- a/examples/simple_callable_trace.py
+++ b/examples/simple_callable_trace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import paddle
 
 from paddlefx import symbolic_trace

--- a/examples/simple_callback.py
+++ b/examples/simple_callback.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dis
 import types
 

--- a/examples/simple_callback.py
+++ b/examples/simple_callback.py
@@ -4,12 +4,11 @@ import dis
 import types
 
 from functools import partial
-from typing import List
 
 import paddlefx
 
 
-def simple_callback(frame: types.FrameType, supported_ops: List[str] = []):
+def simple_callback(frame: types.FrameType, supported_ops: list[str] = []):
     # TODO: add a method for frame skiping
     if frame.f_code.co_name not in supported_ops:
         return None

--- a/examples/simple_dynamo.py
+++ b/examples/simple_dynamo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 import paddle

--- a/examples/simple_dynamo.py
+++ b/examples/simple_dynamo.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-from typing import List
-
 import paddle
 import paddle.nn
 
 import paddlefx
 
 
-def my_compiler(gl: paddlefx.GraphLayer, example_inputs: List[paddle.Tensor] = None):
+def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = None):
     print("my_compiler() called with FX graph:")
     gl.graph.print_tabular()
     return gl.forward

--- a/examples/simple_net_trace.py
+++ b/examples/simple_net_trace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import paddle
 import paddle.nn
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,12 @@ lines_between_types = 1
 known_first_party = ["paddlefx"]
 add_imports = ["from __future__ import annotations"]
 
+# https://beta.ruff.rs/docs/configuration/
+[tool.ruff]
+select = ["UP"]
+ignore = ["UP015"]
+target-version = "py38"
+
 [tool.pytest.ini_options]
 minversion = "7.0.0"
 pythonpath = "tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ workers = 4
 profile = "black"
 lines_between_types = 1
 known_first_party = ["paddlefx"]
+add_imports = ["from __future__ import annotations"]
 
 [tool.pytest.ini_options]
 minversion = "7.0.0"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import os.path as _osp
 import pathlib

--- a/src/paddlefx/__init__.py
+++ b/src/paddlefx/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 try:
     from ._version import version as __version__
     from ._version import version_tuple

--- a/src/paddlefx/eval_frame.py
+++ b/src/paddlefx/eval_frame.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import dataclasses
 import dis
 import types
 
-from typing import Callable, List
+from typing import Callable
 
 from ._eval_frame import set_eval_frame
 from .translator import InstructionTranslator, convert_instruction
@@ -40,7 +42,7 @@ class DynamoContext:
 def _compile(
     frame: types.FrameType,
     compiler_fn: Callable,
-    supported_ops: List[str] = [],
+    supported_ops: list[str] = [],
 ):
     # NOTE: use supported_ops for frame skiping, eg: supported_ops = ['func', 'add']
     # TODO: add a method for frame skiping
@@ -63,13 +65,13 @@ def _compile(
 
 
 def convert_frame_assert(compiler_fn: Callable):
-    def _convert_frame_assert(frame: types.FrameType, supported_ops: List[str] = []):
+    def _convert_frame_assert(frame: types.FrameType, supported_ops: list[str] = []):
         return _compile(frame, compiler_fn, supported_ops)
 
     return _convert_frame_assert
 
 
-def optimize(backend=None, supported_ops: List[str] = []):
+def optimize(backend=None, supported_ops: list[str] = []):
     def convert_frame(compiler_fn):
         inner_convert = convert_frame_assert(compiler_fn)
 

--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import builtins
 import keyword
 
-from typing import Any, Optional
+from typing import Any
 
 import paddle
 import paddle.nn
@@ -101,7 +101,7 @@ class _InsertPoint:
 
 
 class _node_list:
-    def __init__(self, graph: 'Graph', direction: str = '_next'):
+    def __init__(self, graph: Graph, direction: str = '_next'):
         assert direction in ['_next', '_prev']
         self.graph = graph
         self.direction = direction
@@ -203,13 +203,13 @@ class Graph:
             map_arg(to_erase.kwargs, lambda n: None),
         )
 
-    def inserting_before(self, n: Optional[Node] = None):
+    def inserting_before(self, n: Node | None = None):
         if n is None:
             return self.inserting_after(self._root)
         assert n.graph == self, "Node to insert before is not in graph."
         return _InsertPoint(self, n.prepend)
 
-    def inserting_after(self, n: Optional[Node] = None):
+    def inserting_after(self, n: Node | None = None):
         if n is None:
             return self.inserting_before(self._root)
         assert n.graph == self, "Node to insert after is not in graph."

--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import builtins
 import keyword
 

--- a/src/paddlefx/graph_layer.py
+++ b/src/paddlefx/graph_layer.py
@@ -1,4 +1,6 @@
 # type: ignore
+from __future__ import annotations
+
 import linecache
 
 import paddle

--- a/src/paddlefx/interpreter.py
+++ b/src/paddlefx/interpreter.py
@@ -32,7 +32,7 @@ class Interpreter:
                 self.env[node] = self.run_node(node)
             except Exception as e:
                 msg = f"While executing {node}"
-                msg = '{}\n\n{}'.format(e.args[0], msg) if e.args else str(msg)
+                msg = f'{e.args[0]}\n\n{msg}' if e.args else str(msg)
                 e.args = (msg,) + e.args[1:]
                 if isinstance(e, KeyError):
                     raise RuntimeError(*e.args) from e

--- a/src/paddlefx/interpreter.py
+++ b/src/paddlefx/interpreter.py
@@ -68,8 +68,8 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node.
-            args (tuple): Tuple of positional args for this invocation
-            kwargs (dict): Dict of keyword arguments for this invocation
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
 
         Returns:
             Any: The argument value that was retrieved.
@@ -96,8 +96,8 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node.
-            args (tuple): Tuple of positional args for this invocation
-            kwargs (dict): Dict of keyword arguments for this invocation
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
 
         Return:
             Any: The value of the attribute that was retrieved
@@ -110,8 +110,8 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node.
-            args (tuple): Tuple of positional args for this invocation
-            kwargs (dict): Dict of keyword arguments for this invocation
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
 
         Return
             Any: The value returned by the function invocation
@@ -126,8 +126,8 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node.
-            args (tuple): Tuple of positional args for this invocation
-            kwargs (dict): Dict of keyword arguments for this invocation
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
 
         Return
             Any: The value returned by the method invocation
@@ -144,8 +144,8 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node.
-            args (tuple): Tuple of positional args for this invocation
-            kwargs (dict): Dict of keyword arguments for this invocation
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
 
         Return
             Any: The value returned by the module invocation
@@ -164,8 +164,8 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node.
-            args (tuple): Tuple of positional args for this invocation
-            kwargs (dict): Dict of keyword arguments for this invocation
+            args (Tuple): Tuple of positional args for this invocation
+            kwargs (Dict): Dict of keyword arguments for this invocation
 
         Return:
             Any: The return value referenced by the output node
@@ -200,7 +200,7 @@ class Interpreter:
             n (Node): The node for which ``args`` and ``kwargs`` should be fetched.
 
         Return:
-            tuple[tuple, dict]: ``args`` and ``kwargs`` with concrete values for ``n``.
+            Tuple[Tuple, Dict]: ``args`` and ``kwargs`` with concrete values for ``n``.
         """
         args = self.map_nodes_to_values(n.args, n)
         #        assert isinstance(args, tuple)

--- a/src/paddlefx/interpreter.py
+++ b/src/paddlefx/interpreter.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Iterator, Tuple
+from __future__ import annotations
+
+from typing import Any, Iterator
 
 from .graph_layer import GraphLayer
 from .node import Node, map_arg
@@ -10,7 +12,7 @@ class Interpreter:
     def __init__(self, module: GraphLayer):
         assert isinstance(module, GraphLayer)
         self.module = module
-        self.env: Dict[Node, Any] = {}
+        self.env: dict[Node, Any] = {}
         self.name = "Interpreter"
 
     def run(self, *args) -> Any:
@@ -58,7 +60,7 @@ class Interpreter:
         return getattr(self, n.op)(n.target, args, kwargs)
 
     # Main Node running APIs
-    def placeholder(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+    def placeholder(self, target, args: tuple, kwargs: dict[str, Any]) -> Any:
         """Execute a ``placeholder`` node. Note that this is stateful:
         ``Interpreter`` maintains an internal iterator over
         arguments passed to ``run`` and this method returns
@@ -66,8 +68,8 @@ class Interpreter:
 
         Args:
             target (Target): The call target for this node.
-            args (Tuple): Tuple of positional args for this invocation
-            kwargs (Dict): Dict of keyword arguments for this invocation
+            args (tuple): Tuple of positional args for this invocation
+            kwargs (dict): Dict of keyword arguments for this invocation
 
         Returns:
             Any: The argument value that was retrieved.
@@ -88,14 +90,14 @@ class Interpreter:
                         f'Expected positional argument for parameter {target}, but one was not passed in!'
                     ) from si
 
-    def get_attr(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+    def get_attr(self, target, args: tuple, kwargs: dict[str, Any]) -> Any:
         """Execute a ``get_attr`` node. Will retrieve an attribute
         value from the ``Module`` hierarchy of ``self.module``.
 
         Args:
             target (Target): The call target for this node.
-            args (Tuple): Tuple of positional args for this invocation
-            kwargs (Dict): Dict of keyword arguments for this invocation
+            args (tuple): Tuple of positional args for this invocation
+            kwargs (dict): Dict of keyword arguments for this invocation
 
         Return:
             Any: The value of the attribute that was retrieved
@@ -103,13 +105,13 @@ class Interpreter:
         assert isinstance(target, str)
         return self.fetch_attr(target)
 
-    def call_function(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+    def call_function(self, target, args: tuple, kwargs: dict[str, Any]) -> Any:
         """Execute a ``call_function`` node and return the result.
 
         Args:
             target (Target): The call target for this node.
-            args (Tuple): Tuple of positional args for this invocation
-            kwargs (Dict): Dict of keyword arguments for this invocation
+            args (tuple): Tuple of positional args for this invocation
+            kwargs (dict): Dict of keyword arguments for this invocation
 
         Return
             Any: The value returned by the function invocation
@@ -119,13 +121,13 @@ class Interpreter:
         # Execute the function and return the result
         return target(*args, **kwargs)
 
-    def call_method(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+    def call_method(self, target, args: tuple, kwargs: dict[str, Any]) -> Any:
         """Execute a ``call_method`` node and return the result.
 
         Args:
             target (Target): The call target for this node.
-            args (Tuple): Tuple of positional args for this invocation
-            kwargs (Dict): Dict of keyword arguments for this invocation
+            args (tuple): Tuple of positional args for this invocation
+            kwargs (dict): Dict of keyword arguments for this invocation
 
         Return
             Any: The value returned by the method invocation
@@ -137,13 +139,13 @@ class Interpreter:
         assert isinstance(target, str)
         return getattr(self_obj, target)(*args_tail, **kwargs)
 
-    def call_module(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+    def call_module(self, target, args: tuple, kwargs: dict[str, Any]) -> Any:
         """Execute a ``call_module`` node and return the result.
 
         Args:
             target (Target): The call target for this node.
-            args (Tuple): Tuple of positional args for this invocation
-            kwargs (Dict): Dict of keyword arguments for this invocation
+            args (tuple): Tuple of positional args for this invocation
+            kwargs (dict): Dict of keyword arguments for this invocation
 
         Return
             Any: The value returned by the module invocation
@@ -156,14 +158,14 @@ class Interpreter:
 
         return submod(*args, **kwargs)
 
-    def output(self, target, args: Tuple, kwargs: Dict[str, Any]) -> Any:
+    def output(self, target, args: tuple, kwargs: dict[str, Any]) -> Any:
         """Execute an ``output`` node. This really just retrieves
         the value referenced by the ``output`` node and returns it.
 
         Args:
             target (Target): The call target for this node.
-            args (Tuple): Tuple of positional args for this invocation
-            kwargs (Dict): Dict of keyword arguments for this invocation
+            args (tuple): Tuple of positional args for this invocation
+            kwargs (dict): Dict of keyword arguments for this invocation
 
         Return:
             Any: The return value referenced by the output node
@@ -190,7 +192,7 @@ class Interpreter:
             attr_itr = getattr(attr_itr, atom)
         return attr_itr
 
-    def fetch_args_kwargs_from_env(self, n: Node) -> Tuple[Tuple, Dict]:
+    def fetch_args_kwargs_from_env(self, n: Node) -> tuple[tuple, dict]:
         """Fetch the concrete values of ``args`` and ``kwargs`` of node ``n``
         from the current execution environment.
 
@@ -198,7 +200,7 @@ class Interpreter:
             n (Node): The node for which ``args`` and ``kwargs`` should be fetched.
 
         Return:
-            Tuple[Tuple, Dict]: ``args`` and ``kwargs`` with concrete values for ``n``.
+            tuple[tuple, dict]: ``args`` and ``kwargs`` with concrete values for ``n``.
         """
         args = self.map_nodes_to_values(n.args, n)
         #        assert isinstance(args, tuple)

--- a/src/paddlefx/node.py
+++ b/src/paddlefx/node.py
@@ -90,7 +90,7 @@ class Node:
         self._mark_uses(self.args, self)
         self._mark_uses(self.kwargs, self)
 
-    def replace_all_uses_with(self, replace_with: 'Node'):
+    def replace_all_uses_with(self, replace_with: Node):
         to_process = list(self.users)
         for use_node in to_process:
 

--- a/src/paddlefx/node.py
+++ b/src/paddlefx/node.py
@@ -1,6 +1,6 @@
 import warnings
 
-from typing import Any, Callable, Union
+from typing import Any, Callable, Dict, Union
 
 import paddle
 
@@ -16,9 +16,15 @@ class Node:
         self.op = op  # the kind of operation = placeholder|call_method|call_module|call_function|getattr
         self.target = target  # for method/module/function, the name of the method/module/function/attr
         # being invoked, e.g add, layer1, or paddle.add
-        self.args = args
-        self.kwargs = kwargs
-        self.uses = 0
+
+        # Currently, we do not support directly set the args and kwargs of a Node.
+        # Please use `_update_args_kwargs` instead.
+        self.args = ()
+        self.kwargs = {}
+        self._update_args_kwargs(args, kwargs)
+        # Is a dict to act as an "ordered set". Keys are significant, value dont-care
+        self.users: Dict['Node', None] = {}
+
         self._prev = self
         self._next = self
         self._erased = False
@@ -53,6 +59,49 @@ class Node:
         p, n = self._prev, self._next
         p._next, n._prev = n, p
         self._prev, self._next = self, self
+
+    def _mark_uses(self, a, user):
+        def add_use(n: Node):
+            n.users.setdefault(user)
+            return n
+
+        map_arg(a, add_use)
+
+    def _mark_unused(self, a, user):
+        def remove_use(n: Node):
+            if user in n.users:
+                n.users.pop(user)
+            return n
+
+        map_arg(a, remove_use)
+
+    def _update_args_kwargs(self, new_args, new_kwargs):
+        # 1. Notify all the nodes that we used to use that we no longer use them
+        self._mark_unused(self.args, self)
+        self._mark_unused(self.kwargs, self)
+
+        # 2. Update the args and kwargs
+        self.args = new_args
+        self.kwargs = new_kwargs
+
+        # 3. Notify all the nodes that we now use that we use them
+        self._mark_uses(self.args, self)
+        self._mark_uses(self.kwargs, self)
+
+    def replace_all_uses_with(self, replace_with: 'Node'):
+        to_process = list(self.users)
+        for use_node in to_process:
+
+            def maybe_replace_node(n: Node) -> Node:
+                if n == self:
+                    return replace_with
+                else:
+                    return n
+
+            use_node._update_args_kwargs(
+                map_arg(use_node.args, maybe_replace_node),
+                map_arg(use_node.kwargs, maybe_replace_node),
+            )
 
 
 def map_aggregate(a, fn):

--- a/src/paddlefx/node.py
+++ b/src/paddlefx/node.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import warnings
 
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Union
 
 import paddle
 
@@ -23,7 +25,7 @@ class Node:
         self.kwargs = {}
         self._update_args_kwargs(args, kwargs)
         # Is a dict to act as an "ordered set". Keys are significant, value dont-care
-        self.users: Dict['Node', None] = {}
+        self.users: dict[Node, None] = {}
 
         self._prev = self
         self._next = self
@@ -33,14 +35,14 @@ class Node:
         return self.name
 
     @property
-    def next(self) -> 'Node':
+    def next(self) -> Node:
         return self._next
 
     @property
-    def prev(self) -> 'Node':
+    def prev(self) -> Node:
         return self._prev
 
-    def prepend(self, x: 'Node') -> None:
+    def prepend(self, x: Node) -> None:
         assert self.graph == x.graph, "Attempting to move a Node into a different Graph"
         if self == x:
             warnings.warn(
@@ -52,7 +54,7 @@ class Node:
         p._next, x._prev = x, p
         x._next, self._prev = self, x
 
-    def append(self, x: 'Node') -> None:
+    def append(self, x: Node) -> None:
         self._next.prepend(x)
 
     def _remove_from_list(self):

--- a/src/paddlefx/proxy.py
+++ b/src/paddlefx/proxy.py
@@ -5,8 +5,6 @@ import inspect
 import operator
 import typing
 
-from typing import Optional
-
 if typing.TYPE_CHECKING:
     from .node import Node
     from .symbolic_trace import Tracer
@@ -54,7 +52,7 @@ class Attribute(Proxy):
         self.root = root
         self.attr = attr
         self.tracer = root.tracer
-        self._node: Optional[Node] = None
+        self._node: Node | None = None
 
     @property
     def node(self):

--- a/src/paddlefx/symbolic_trace.py
+++ b/src/paddlefx/symbolic_trace.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import builtins
 import functools
 
-from typing import Any, Callable, Dict, NamedTuple
+from typing import Any, Callable, NamedTuple
 
 import paddle
 import paddle.nn
@@ -153,7 +155,7 @@ def _create_wrapped_func(orig_fn):
     return wrapped
 
 
-def _autowrap_check(patcher: _Patcher, frame_dict: Dict[str, Any]):
+def _autowrap_check(patcher: _Patcher, frame_dict: dict[str, Any]):
     if patcher.visit_once(frame_dict):
         for name, value in frame_dict.items():
             if (

--- a/src/paddlefx/translator.py
+++ b/src/paddlefx/translator.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import dataclasses
 import dis
 import operator
 import types
 
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import paddle
 import paddle.nn
@@ -53,12 +55,12 @@ def convert_instruction(i: dis.Instruction):
 class InstructionTranslatorBase:
     def __init__(
         self,
-        instructions: List[Instruction],
+        instructions: list[Instruction],
         frame: types.FrameType,
         compiler_fn: Any,
         output: OutputGraph,
     ):
-        self.instructions: List[Instruction] = instructions
+        self.instructions: list[Instruction] = instructions
         self.frame: types.FrameType = frame
         self.compiler_fn = compiler_fn
         self.output: OutputGraph = output
@@ -111,7 +113,7 @@ class InstructionTranslatorBase:
 class InstructionTranslator(InstructionTranslatorBase):
     def __init__(
         self,
-        instructions: List[Instruction],
+        instructions: list[Instruction],
         frame: types.FrameType,
         compiler_fn: Any,
     ):

--- a/src/paddlefx/translator.py
+++ b/src/paddlefx/translator.py
@@ -5,7 +5,7 @@ import dis
 import operator
 import types
 
-from typing import Any, Optional
+from typing import Any
 
 import paddle
 import paddle.nn
@@ -25,13 +25,13 @@ class Instruction:
 
     opcode: int
     opname: str
-    arg: Optional[int]
+    arg: int | None
     argval: Any
-    offset: Optional[int] = None
-    starts_line: Optional[int] = None
+    offset: int | None = None
+    starts_line: int | None = None
     is_jump_target: bool = False
     # extra fields to make modification easier:
-    target: Optional["Instruction"] = None
+    target: Instruction | None = None
 
     def __hash__(self):
         return id(self)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import paddlefx
 
 

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 import paddle


### PR DESCRIPTION
- 在 isort 里添加选项 `add_imports = ["from __future__ import annotations"]` 以自动添加该 future import，避免忘记添加的问题
- 添加新的工具 Ruff 的 [pyupgrade rules](https://beta.ruff.rs/docs/rules/#pyupgrade-up) 以自动转写在包含 `from __future__ import annotations` 的情况下使用了不必要的引号包裹、从 typing 中 import 的 `Dict` -> `dict`、`List` -> `list` 等情形，以保证 type hint 的一致性，且更加现代～