### PR TITLE
fix bug in print_tabular and add some new print_tabular mode

### DIFF
--- a/examples/resnet_trace.py
+++ b/examples/resnet_trace.py
@@ -17,4 +17,6 @@ traced_output = traced_layer(example_input)
 assert paddle.allclose(orig_output, traced_output)
 
 print(f"python IR for {type(net).__name__}")
-traced_layer.graph.print_tabular()
+traced_layer.graph.print_tabular(print_mode="tabular")
+traced_layer.graph.print_tabular(print_mode="rich")
+traced_layer.graph.print_tabular(print_mode="raw")

--- a/examples/resnet_trace.py
+++ b/examples/resnet_trace.py
@@ -17,6 +17,6 @@ traced_output = traced_layer(example_input)
 assert paddle.allclose(orig_output, traced_output)
 
 print(f"python IR for {type(net).__name__}")
-traced_layer.graph.print_tabular(print_mode="tabular")
+traced_layer.graph.print_tabular(print_mode="tabulate")
 traced_layer.graph.print_tabular(print_mode="rich")
 traced_layer.graph.print_tabular(print_mode="raw")

--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -285,13 +285,13 @@ class Graph:
         """
         try:
             from tabulate import tabulate
+            node_specs = [[n.op, n.name, n.target, n.args, n.kwargs] for n in self.nodes]
+            print(
+                tabulate(node_specs, headers=['opcode', 'name', 'target', 'args', 'kwargs'])
+            )
         except ImportError:
             print(
                 "`print_tabular` relies on the library `tabulate`, "
                 "which could not be found on this machine. Run `pip "
                 "install tabulate` to install the library."
             )
-        node_specs = [[n.op, n.name, n.target, n.args, n.kwargs] for n in self.nodes]
-        print(
-            tabulate(node_specs, headers=['opcode', 'name', 'target', 'args', 'kwargs'])
-        )

--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -283,7 +283,7 @@ class Graph:
 
         Note that this API requires the ``tabulate`` module to be installed.
         """
-        assert print_mode in ["raw", "tablulate", "rich"]
+        assert print_mode in ["raw", "tabulate", "rich"]
         if print_mode == "raw":
             node_specs = [
                 " ".join(
@@ -293,7 +293,7 @@ class Graph:
             ]
             print(" ".join(['opcode', 'name', 'target', 'args', 'kwargs']))
             print("\n".join(node_specs))
-        elif print_mode == "tablulate":
+        elif print_mode == "tabulate":
             try:
                 from tabulate import tabulate
 

--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -277,21 +277,65 @@ class Graph:
         src = ''.join(body)
         return src, free_vars
 
-    def print_tabular(self):
+    def print_tabular(self, print_mode="tablulate"):
         """Prints the intermediate representation of the graph in tabular
         format.
 
         Note that this API requires the ``tabulate`` module to be installed.
         """
-        try:
-            from tabulate import tabulate
-            node_specs = [[n.op, n.name, n.target, n.args, n.kwargs] for n in self.nodes]
-            print(
-                tabulate(node_specs, headers=['opcode', 'name', 'target', 'args', 'kwargs'])
-            )
-        except ImportError:
-            print(
-                "`print_tabular` relies on the library `tabulate`, "
-                "which could not be found on this machine. Run `pip "
-                "install tabulate` to install the library."
-            )
+        assert print_mode in ["raw", "tablulate", "rich"]
+        if print_mode == "raw":
+            node_specs = [
+                " ".join(
+                    map(str, [v for v in [n.op, n.name, n.target, n.args, n.kwargs]])
+                )
+                for n in self.nodes
+            ]
+            print(" ".join(['opcode', 'name', 'target', 'args', 'kwargs']))
+            print("\n".join(node_specs))
+        elif print_mode == "tablulate":
+            try:
+                from tabulate import tabulate
+
+                node_specs = [
+                    [n.op, n.name, n.target, n.args, n.kwargs] for n in self.nodes
+                ]
+                print(
+                    tabulate(
+                        node_specs,
+                        headers=['opcode', 'name', 'target', 'args', 'kwargs'],
+                    )
+                )
+            except ImportError:
+                import warnings
+
+                warnings.warn(
+                    "`print_tabular` relies on the library `tabulate`, "
+                    "which could not be found on this machine. Run `pip "
+                    "install tabulate` to install the library."
+                )
+                self.print_tabular("raw")
+        elif print_mode == "rich":
+            try:
+                import rich
+                import rich.table
+
+                table = rich.table.Table(
+                    'opcode', 'name', 'target', 'args', 'kwargs', expand=True
+                )
+                for n in self.nodes:
+                    table.add_row(
+                        *map(
+                            str, [v for v in [n.op, n.name, n.target, n.args, n.kwargs]]
+                        )
+                    )
+                rich.print(table)
+            except ImportError:
+                import warnings
+
+                warnings.warn(
+                    "`print_tabular` relies on the library `rich`, "
+                    "which could not be found on this machine. Run `pip "
+                    "install rich` to install the library."
+                )
+                self.print_tabular("raw")

--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -277,7 +277,7 @@ class Graph:
         src = ''.join(body)
         return src, free_vars
 
-    def print_tabular(self, print_mode="tablulate"):
+    def print_tabular(self, print_mode="tabulate"):
         """Prints the intermediate representation of the graph in tabular
         format.
 

--- a/src/paddlefx/graph_layer.py
+++ b/src/paddlefx/graph_layer.py
@@ -67,11 +67,11 @@ class GraphLayer(paddle.nn.Layer):
     def _generate_forward(self):
         body, free_variables = self.graph.python_code(root_module='self')
         body = '\n'.join('    ' + line for line in body.split('\n')) + '\n'
-        self.src = (
-            f"def forward(self, {', '.join(free_variables)}):\n"
-            f"    self = self.root\n"
-            f"{body}"
-        )
+        self.src = f"""\
+def forward(self, {', '.join(free_variables)}):
+    self = self.root
+{body}
+"""
         # print(self.src)
         # install forward into the classes dictionary, this is what normally happens in the
         # 'class' statement

--- a/src/paddlefx/graph_layer.py
+++ b/src/paddlefx/graph_layer.py
@@ -67,11 +67,11 @@ class GraphLayer(paddle.nn.Layer):
     def _generate_forward(self):
         body, free_variables = self.graph.python_code(root_module='self')
         body = '\n'.join('    ' + line for line in body.split('\n')) + '\n'
-        self.src = f"""\
-def forward(self, {', '.join(free_variables)}):
-    self = self.root
-{body}
-"""
+        self.src = (
+            f"def forward(self, {', '.join(free_variables)}):\n"
+            f"    self = self.root\n"
+            f"{body}"
+        )
         # print(self.src)
         # install forward into the classes dictionary, this is what normally happens in the
         # 'class' statement

--- a/src/paddlefx/graph_viewer.py
+++ b/src/paddlefx/graph_viewer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import paddle
+import paddle.nn
 import pydot
 
 import paddlefx


### PR DESCRIPTION
print_tabular函数原本的代码是
```python
try:
    from tabulate import tabulate
except ImportError:
    print(
        "`print_tabular` relies on the library `tabulate`, "
        "which could not be found on this machine. Run `pip "
        "install tabulate` to install the library."
    )
node_specs = [[n.op, n.name, n.target, n.args, n.kwargs] for n in self.nodes]
print(
    tabulate(node_specs, headers=['opcode', 'name', 'target', 'args', 'kwargs'])
)
```
这样当 from tabulate import tabulate 失败时会打印提示信息，但是在执行到
```python
print(
    tabulate(node_specs, headers=['opcode', 'name', 'target', 'args', 'kwargs'])
)
```
时依然会报错，但是应该在except ImportError:时直接处理，例如改成
```python
try:
    from tabulate import tabulate
except ImportError:
    ImportError(
        "`print_tabular` relies on the library `tabulate`, "
        "which could not be found on this machine. Run `pip "
        "install tabulate` to install the library."
    )
node_specs = [[n.op, n.name, n.target, n.args, n.kwargs] for n in self.nodes]
print(
    tabulate(node_specs, headers=['opcode', 'name', 'target', 'args', 'kwargs'])
)
```

但是print_tabular应该不对后续执行产生影响，所以应该改成
```python
try:
    from tabulate import tabulate
    node_specs = [[n.op, n.name, n.target, n.args, n.kwargs] for n in self.nodes]
    print(
        tabulate(node_specs, headers=['opcode', 'name', 'target', 'args', 'kwargs'])
    )
except ImportError:
    print(
        "`print_tabular` relies on the library `tabulate`, "
        "which could not be found on this machine. Run `pip "
        "install tabulate` to install the library."
    )
```
这样的话即使导入失败也仅是输出错误信息但不会终止后续的代码执行


当用户没有安装tabulate时，我们也可以警告用户使用其他的模式，并自动切换到基础输出，这个pr实现了rich的输出，和一个以空格为分割的基础输出。


