### PR TITLE
fix bug in codegen when function is a node

### DIFF
--- a/examples/simple_dynamo.py
+++ b/examples/simple_dynamo.py
@@ -10,6 +10,7 @@ import paddlefx
 def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = None):
     print("my_compiler() called with FX graph:")
     gl.graph.print_tabular()
+    print(gl.get_source())
     return gl.forward
 
 
@@ -88,14 +89,13 @@ class ExampleNet(paddle.nn.Layer):
         self.fc = [paddle.nn.Linear(1, 1), paddle.nn.Linear(1, 1)]
 
     def forward(self, a, b):
-        c = self.fc[0](a)
-        d = self.fc[1](b)
+        c = self.fc[0](a[0])
+        d = self.fc[1](b[0])
         e = paddle.add(c, d)
         return e
 
 
 net = ExampleNet()
-
 optimized_func = paddlefx.optimize(my_compiler)(net)
 
 original_res = net(in_a, in_b)

--- a/src/paddlefx/graph.py
+++ b/src/paddlefx/graph.py
@@ -264,6 +264,11 @@ class Graph:
                         f'{node.name} = {magic_methods[node.target.__name__].format(*(repr(a) for a in node.args))}\n'
                     )
                     continue
+                if isinstance(node.target, Node):
+                    body.append(
+                        f'{node.name} = {node.target}({_format_args(node.args, node.kwargs)})\n'
+                    )
+                    continue
                 qualified_name = _qualified_name(node.target)
                 if (
                     qualified_name == 'getattr'

--- a/src/paddlefx/symbolic_trace.py
+++ b/src/paddlefx/symbolic_trace.py
@@ -232,6 +232,15 @@ class Tracer:
     def create_node(self, op, target, args=None, kwargs=None, name=None):
         return self.graph.create_node(op, target, args, kwargs, name)
 
+    def get_param(self, target):
+        return self.graph.get_param(target)
+
+    def placeholder(self, name):
+        return self.graph.placeholder(name)
+
+    def call_module(self, target, args, kwargs):
+        return self.graph.call_module(target, args, kwargs)
+
     def create_arg(self, a):
         if isinstance(a, (tuple, list)):
             return type(a)(self.create_arg(elem) for elem in a)

--- a/src/paddlefx/translator.py
+++ b/src/paddlefx/translator.py
@@ -100,7 +100,6 @@ BINARY_MAPPER = {
     'ipow': 'INPLACE_POWER',
     'isub': 'INPLACE_SUBTRACT',
     'itruediv': 'INPLACE_TRUE_DIVIDE',
-    'is_': 'IS_OP',
 }
 
 UNARY_MAPPER = {'not_': 'UNARY_NOT', 'inv': 'UNARY_INVERT'}
@@ -334,6 +333,27 @@ class InstructionTranslatorBase(metaclass=InstructionTranslatorMeta):
         }
         op = getattr(operator, op_mapper[inst.argval])
         args = self.popn(2)
+        res = self.output.create_node('call_function', op, args, {})
+        self.push(res)
+
+    # note: python3.9+
+    def IS_OP(self, inst: Instruction):
+        invert = inst.argval
+        args = self.popn(2)
+        if invert:
+            op = operator.is_
+        else:
+            op = operator.is_not
+        res = self.output.create_node('call_function', op, args, {})
+        self.push(res)
+
+    def CONTAINS_OP(self, inst: Instruction):
+        invert = inst.argval
+        args = self.popn(2)
+        if invert:
+            op = operator.contains
+        else:
+            op = lambda a, b: b not in a
         res = self.output.create_node('call_function', op, args, {})
         self.push(res)
 


### PR DESCRIPTION
## 1. codegen中fn为Node的问题
当类似这种情况时
```python
def forward(self, a, b):
      c = self.fc[0](a[0])
      d = self.fc[1](b[0])
```
self是一个Proxy，如果不做额外处理把self.fc变成是一个Attribute，那么self.fc[0]将会是一个Proxy，他实际上没有__call__方法。
一个临时的解决方法就是额外处理把self.fc变成get_param的Node，但是这样就导致了在codegen的时候，
fn可能为Node，所以需要判断fn是否为Node，如果为node就直接输出他的name，而不是计算module。

我想到的几个实现方法
1. 可以单独实现一个Item类，他类似Attribute，在最后的setattr(Proxy, as_magic, impl)里单独处理一下getitem，或者直接实现在__getitem__里。
2. 单独实现一个Self类或者Module，可以继承Proxy也可以独立出来，用来单独处理self的问题，不管是self.abc()还是`self.abc[0]()`，都转换为call_module，call_module的target的类型可以规定为Module做后续处理。
3. 在translator里单独处理self，可能需要考虑的inst种类比较多

## 2. 给Tracer添加三个简化调用Graph的方法
这3个方法（get_param，placeholder，call_module）已经在Graph里实现了，但是没有被加进tracer中，所以实际上tracer里使用的时候还是有很多create_node。

## 3. 添加CONTAINS_OP，并且修复IS_OP
CONTAINS_OP和IS_OP暂时还不能归类到BINARY OP里，因为他们都有一个revert参数，用来表示is not或者not in。

