### PR TITLE
supporting tracing resnet18

### DIFF
--- a/src/paddlefx/pyeval.py
+++ b/src/paddlefx/pyeval.py
@@ -424,8 +424,8 @@ class PyEvalBase:
         self.push(self.symbolic_locals[name])
         if name.startswith("___stack"):
             self.symbolic_locals.pop(name)
-        if name in ['self']:
-            self.symbolic_locals.pop(name)
+        # if name in ['self']:
+        #     self.symbolic_locals.pop(name)
 
     def STORE_FAST(self, inst: Instruction):
         self.symbolic_locals[inst.argval] = self.pop()

--- a/src/paddlefx/symvar.py
+++ b/src/paddlefx/symvar.py
@@ -52,9 +52,19 @@ class SymVar:
 
         if var.__module__.startswith("paddle"):
             # TODO: support multiple ouputs and containers
-            ot = args[0].vtype
-            output = graph.call_function(var, args, kwargs, ot)
-            return SymVar(vtype=ot, node=output)
+            if 'nn.layer' in var.__module__:
+                ot = args[0].vtype
+                target = ''
+                for name, layer in tx.f_locals['self']._sub_layers.items():
+                    if var is layer:
+                        target = name
+                        break
+                output = graph.call_module(target, args, kwargs)
+                return SymVar(vtype=ot, node=output)
+            else:
+                ot = args[0].vtype
+                output = graph.call_function(var, args, kwargs, ot)
+                return SymVar(vtype=ot, node=output)
         elif inspect.isbuiltin(var):
             if var is print:
                 raise NotImplementedError("print() is not supported")


### PR DESCRIPTION
尝试解决该 [Issues](https://github.com/PFCCLab/paddlefx/issues/65)
```
import paddle
import paddle.nn as nn

import paddlefx


def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = None):
    print("my_compiler() called with FX graph:")
    gl.graph.print_tabular()
    print(gl.get_source())
    return gl.forward

class Model(nn.Layer):
    def __init__(
        self,
        depth=50,
        width=64,
        num_classes=1000,
        with_pool=True,
        groups=1,
    ):
        super().__init__()
        self._norm_layer = nn.BatchNorm2D

        self.inplanes = 64

        self.conv1 = nn.Conv2D(
            3,
            self.inplanes,
            kernel_size=7,
            stride=2,
            padding=3,
            bias_attr=False,
        )
        self.bn1 = self._norm_layer(self.inplanes)
        self.relu = nn.ReLU()
        self.maxPool = nn.MaxPool2D(kernel_size=3, stride=2, padding=1)
    def forward(self, x):
        x = self.conv1(x)
        x = self.bn1(x)
        x = self.relu(x)
        x = self.maxPool(x)
        return x

net = Model()
net = paddlefx.optimize(my_compiler)(net)
example_input = paddle.rand([1, 3, 1, 1])
output = net(example_input)
print(output.shape)
```

目前程序能够跑通了，但是存在一个问题：输出的 shape 不对，正确的应该是 [1 64, 1, 1], 可是 tracing 后输出的 shape 却是 [64, 1, 1]。我觉得应该和我修改的部分没有关系，可能是之前的某处代码有误，不知道具体是什么问题。麻烦能帮忙看看 @gglin001 