### PR TITLE
spport tvm as backend

### DIFF
--- a/examples/TODO/resnet_dynamo.py
+++ b/examples/TODO/resnet_dynamo.py
@@ -18,7 +18,7 @@ def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = N
 
 
 net = resnet18()
-optimized_net = paddlefx.optimize(my_compiler)(net)
+optimized_net = paddlefx.optimize(backend=my_compiler)(net)
 
 x = paddle.rand([1, 3, 224, 224])
 out = net(x)

--- a/examples/TODO/simple_dynamo.py
+++ b/examples/TODO/simple_dynamo.py
@@ -14,14 +14,14 @@ def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = N
     return gl.forward
 
 
-@paddlefx.optimize(my_compiler)
+@paddlefx.optimize(backend=my_compiler)
 def add(a, b):
     print('\tcall add')
     c = a + b
     return c
 
 
-@paddlefx.optimize(my_compiler)
+@paddlefx.optimize(backend=my_compiler)
 def func(a, b):
     print('\tcall func')
     c = add(a, b)
@@ -52,7 +52,7 @@ def foo(a, b):
     return l
 
 
-optimized_foo = paddlefx.optimize(my_compiler)(foo)
+optimized_foo = paddlefx.optimize(backend=my_compiler)(foo)
 
 original_res = foo(in_a, in_b)
 optimized_res = optimized_foo(in_a, in_b)
@@ -75,7 +75,7 @@ def inplace(a, b):
     return a
 
 
-optimized_foo = paddlefx.optimize(my_compiler)(inplace)
+optimized_foo = paddlefx.optimize(backend=my_compiler)(inplace)
 
 original_res = inplace(in_a, in_b)
 optimized_res = optimized_foo(in_a, in_b)
@@ -96,7 +96,7 @@ class ExampleNet(paddle.nn.Layer):
 
 
 net = ExampleNet()
-optimized_func = paddlefx.optimize(my_compiler)(net)
+optimized_func = paddlefx.optimize(backend=my_compiler)(net)
 
 original_res = net(in_a, in_b)
 optimized_res = optimized_func(in_a, in_b)

--- a/examples/TODO/simple_dynamo.py
+++ b/examples/TODO/simple_dynamo.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import paddle
 import paddle.nn
 
 import paddlefx
+
+logging.getLogger().setLevel(logging.DEBUG)
 
 
 def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = None):

--- a/examples/simple_compiler.py
+++ b/examples/simple_compiler.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 import numpy as np
 import paddle
 import paddle.nn
@@ -9,16 +7,16 @@ import paddle.tensor
 
 import paddlefx
 
-from paddlefx.compiler import CompilerBase
+from paddlefx.compiler import TVMCompiler
 
-logging.getLogger().setLevel(logging.DEBUG)
+# logging.getLogger().setLevel(logging.DEBUG)
 
 
 def add(x, y):
     return x + y
 
 
-optimized_net = paddlefx.optimize(CompilerBase(print_tabular=True))(add)
+optimized_net = paddlefx.optimize(TVMCompiler(print_tabular=True))(add)
 
 x = paddle.rand([1, 224])
 out = add(x, x)

--- a/examples/simple_compiler.py
+++ b/examples/simple_compiler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import paddle
 import paddle.nn
@@ -9,13 +11,18 @@ import paddlefx
 
 from paddlefx.compiler import TVMCompiler
 
-# logging.getLogger().setLevel(logging.DEBUG)
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+def inner_func(x, y):
+    p = x + y
+    q = x / y
+    return p - q
 
 
 def func(x, y):
-    p = x - y
-    q = x + y
-    return q
+    res = inner_func(x, y)
+    return res
 
 
 optimized_net = paddlefx.optimize(func, backend=TVMCompiler(print_tabular=True))

--- a/examples/simple_compiler.py
+++ b/examples/simple_compiler.py
@@ -12,14 +12,17 @@ from paddlefx.compiler import TVMCompiler
 # logging.getLogger().setLevel(logging.DEBUG)
 
 
-def add(x, y):
-    return x + y
+def func(x, y):
+    p = x - y
+    q = x + y
+    return q
 
 
-optimized_net = paddlefx.optimize(add, backend=TVMCompiler(print_tabular=True))
+optimized_net = paddlefx.optimize(func, backend=TVMCompiler(print_tabular=True))
 
 x = paddle.rand([1, 224])
-out = add(x, x)
-res = optimized_net(x, x)
+y = paddle.rand([1, 224])
+out = func(x, y)
+res = optimized_net(x, y)
 
 np.testing.assert_equal(res.numpy(), out.numpy())

--- a/examples/simple_compiler.py
+++ b/examples/simple_compiler.py
@@ -16,7 +16,7 @@ def add(x, y):
     return x + y
 
 
-optimized_net = paddlefx.optimize(TVMCompiler(print_tabular=True))(add)
+optimized_net = paddlefx.optimize(add, backend=TVMCompiler(print_tabular=True))
 
 x = paddle.rand([1, 224])
 out = add(x, x)

--- a/examples/simple_compiler.py
+++ b/examples/simple_compiler.py
@@ -17,14 +17,15 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 
 def inner_func(x, y):
-    p = x + y
-    q = x / y
-    return p - q
+    p = paddle.add(x, y)
+    q = paddle._C_ops.subtract(x, y)
+    z = p * q
+    return z / y
 
 
-def func(x, y):
-    res = inner_func(x, y)
-    return res
+def func(a, b):
+    d = inner_func(a, b)
+    return d
 
 
 optimized_net = paddlefx.optimize(func, backend=TVMCompiler(print_tabular=True))

--- a/examples/simple_compiler.py
+++ b/examples/simple_compiler.py
@@ -11,6 +11,8 @@ import paddlefx
 
 from paddlefx.compiler import TVMCompiler
 
+paddle.seed(0)
+
 logging.getLogger().setLevel(logging.DEBUG)
 
 

--- a/examples/targets/target_0_add.py
+++ b/examples/targets/target_0_add.py
@@ -20,7 +20,7 @@ def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = N
     return gl.forward
 
 
-@paddlefx.optimize(my_compiler)
+@paddlefx.optimize(backend=my_compiler)
 def add(x, y):
     z = x + y
     return z

--- a/examples/targets/target_1_print.py
+++ b/examples/targets/target_1_print.py
@@ -22,7 +22,7 @@ def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = N
     return gl.forward
 
 
-@paddlefx.optimize(my_compiler)
+@paddlefx.optimize(backend=my_compiler)
 def add(x, y):
     z = x + y
     print(z)

--- a/examples/targets/target_2_func.py
+++ b/examples/targets/target_2_func.py
@@ -27,7 +27,7 @@ def func(x, y):
     return z
 
 
-@paddlefx.optimize(my_compiler)
+@paddlefx.optimize(backend=my_compiler)
 def add(a, b):
     d = func(a, b)
     return d

--- a/examples/targets/target_3_add_paddle.py
+++ b/examples/targets/target_3_add_paddle.py
@@ -28,7 +28,7 @@ def func(x, y):
     return o
 
 
-@paddlefx.optimize(my_compiler)
+@paddlefx.optimize(backend=my_compiler)
 def net(a, b):
     c = func(a, b)
     return c

--- a/examples/targets/target_3_add_paddle.py
+++ b/examples/targets/target_3_add_paddle.py
@@ -10,16 +10,12 @@ import paddle._C_ops
 
 import paddlefx
 
+from paddlefx.compiler import TVMCompiler
+
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 # logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 paddle.seed(0)
-
-
-def my_compiler(gl: paddlefx.GraphLayer, example_inputs=None):
-    print("my_compiler() called with FX graph:")
-    gl.graph.print_tabular()
-    return gl.forward
 
 
 def func(x, y):
@@ -28,7 +24,7 @@ def func(x, y):
     return o
 
 
-@paddlefx.optimize(backend=my_compiler)
+@paddlefx.optimize(backend=TVMCompiler(print_tabular=True))
 def net(a, b):
     c = func(a, b)
     return c

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,5 +13,7 @@ pre-commit>=3.0.0
 
 tabulate==0.9.0
 
+apache-tvm>=0.11.1
+
 # debug python with paddle
 opencv-python-headless

--- a/src/paddlefx/codegen.py
+++ b/src/paddlefx/codegen.py
@@ -7,12 +7,12 @@ from typing import TYPE_CHECKING
 
 from .bytecode_transformation import *  # noqa
 from .source import LocalSource
+from .variable_stack import VariableStack
 from .variables.base import TensorVariable
 
 if TYPE_CHECKING:
     from .graph import Node
     from .pyeval import PyEvalBase
-    from .variable_stack import VariableStack
     from .variables.base import VariableBase
 
 

--- a/src/paddlefx/compiler.py
+++ b/src/paddlefx/compiler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 import paddle
 import tvm
@@ -11,42 +11,68 @@ from tvm import te
 import paddlefx
 
 
+def paddle_dtype_to_str(dtype: paddle.dtype) -> str:
+    if dtype == paddle.float32:
+        return "float32"
+    elif dtype == paddle.float64:
+        return "float64"
+    elif dtype == paddle.float16:
+        return "float16"
+    elif dtype == paddle.int32:
+        return "int32"
+    elif dtype == paddle.int64:
+        return "int64"
+    elif dtype == paddle.bool:
+        return "bool"
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+
 class CompilerBase:
     def __init__(self, *, print_tabular: bool = False):
         self.print_tabular = print_tabular
+        self.input_index = 0
 
-    def __call__(self, gl: paddlefx.GraphLayer, inputs: list):
+    def __call__(self, gl: paddlefx.GraphLayer, dummy_inputs: list):
         if self.print_tabular:
             gl.graph.print_tabular()
-        return self.compile(gl, inputs)
+        return self.compile(gl, dummy_inputs)
 
-    def compile(self, gl: paddlefx.GraphLayer, inputs: list) -> Callable:
+    def compile(self, gl: paddlefx.GraphLayer, dummy_inputs: list) -> Callable:
+        dummy_outputs = gl.forward(*dummy_inputs)
         symbol_table = {}
         try:
             for node in gl.graph.nodes:
-                getattr(self, f"compile_{node.op}")(node, symbol_table, inputs)
-            return self.gen_compiled_func(symbol_table, gl, inputs)
+                getattr(self, f"compile_{node.op}")(node, symbol_table, dummy_inputs)
+            self.input_index = 0
+            return self.gen_compiled_func(symbol_table, dummy_outputs)
         except AttributeError as e:
             print(f"AttributeError when compiling graph: {e}")
+            self.input_index = 0
             return gl.forward
 
-    def gen_compiled_func(
-        self, symbol_table: dict, gl: paddlefx.GraphLayer, inputs: list
-    ):
+    def gen_compiled_func(self, symbol_table: dict, dummy_outputs: Any):
         raise NotImplementedError("CompilerBase is a abstract class")
 
 
 class TVMCompiler(CompilerBase):
-    def gen_compiled_func(
-        self, symbol_table: dict, gl: paddlefx.GraphLayer, inputs: list
-    ):
+    def gen_compiled_func(self, symbol_table: dict, dummy_outputs: Any):
         tgt = tvm.target.Target(target="llvm", host="llvm")
         s = te.create_schedule(symbol_table["output"].op)
-        tvm_func = tvm.build(s, tuple(symbol_table.values())[:3], tgt, name="myadd")
+
+        tvm_func = tvm.build(
+            s,
+            [v for k, v in symbol_table.items() if k != "output"],
+            tgt,
+            name=symbol_table["output"].name,
+        )
 
         def compiled_func(*args):
             inputs = [tvm.nd.array(arg.numpy()) for arg in args]
-            output = tvm.nd.array(args[0].numpy())
+            dummy_output = dummy_outputs[0]
+            output = tvm.nd.empty(
+                dummy_output.shape, paddle_dtype_to_str(dummy_output.dtype)
+            )
             tvm_func(*inputs, output)
             output = paddle.to_tensor(output.asnumpy())
             return (output,)
@@ -57,8 +83,11 @@ class TVMCompiler(CompilerBase):
         self, node: paddlefx.Node, symbol_table: dict, inputs: list
     ):
         symbol_table[str(node.name)] = te.placeholder(
-            inputs.pop(0).shape, name=str(node.name)
+            inputs[self.input_index].shape,
+            paddle_dtype_to_str(inputs[self.input_index].dtype),
+            name=str(node.name),
         )
+        self.input_index += 1
 
     def compile_call_function(
         self, node: paddlefx.Node, symbol_table: dict, inputs: list

--- a/src/paddlefx/compiler.py
+++ b/src/paddlefx/compiler.py
@@ -33,17 +33,17 @@ class CompilerBase:
         self.print_tabular = print_tabular
         self.input_index = 0
 
-    def __call__(self, gl: paddlefx.GraphLayer, dummy_inputs: list):
+    def __call__(self, gl: paddlefx.GraphLayer, example_inputs: list):
         if self.print_tabular:
             gl.graph.print_tabular()
-        return self.compile(gl, dummy_inputs)
+        return self.compile(gl, example_inputs)
 
-    def compile(self, gl: paddlefx.GraphLayer, dummy_inputs: list) -> Callable:
-        dummy_outputs = gl.forward(*dummy_inputs)
+    def compile(self, gl: paddlefx.GraphLayer, example_inputs: list) -> Callable:
+        dummy_outputs = gl.forward(*example_inputs)
         symbol_table: dict[str, Any] = {}
         try:
             for node in gl.graph.nodes:
-                getattr(self, f"compile_{node.op}")(node, symbol_table, dummy_inputs)
+                getattr(self, f"compile_{node.op}")(node, symbol_table, example_inputs)
             self.input_index = 0
             return self.gen_compiled_func(symbol_table, dummy_outputs)
         except (AttributeError, NotImplementedError) as e:

--- a/src/paddlefx/compiler.py
+++ b/src/paddlefx/compiler.py
@@ -28,7 +28,7 @@ def paddle_dtype_to_str(dtype: paddle.dtype) -> str:
 
 
 class CompilerBase:
-    def __init__(self, *, print_tabular: bool = False):
+    def __init__(self, *, print_tabular: bool = True):
         self.print_tabular = print_tabular
         self.input_index = 0
 

--- a/src/paddlefx/compiler.py
+++ b/src/paddlefx/compiler.py
@@ -44,10 +44,7 @@ class TVMCompiler(CompilerBase):
             inputs = [tvm.nd.array(arg.numpy()) for arg in args]
             output = tvm.nd.array(args[0].numpy())
             tvm_func(*inputs, output)
-            shape = output.shape
-            print(shape)
-            output = paddle.to_tensor(output.asnumpy()).reshape(shape)
-            print(output.shape)
+            output = paddle.to_tensor(output.asnumpy())
             return output
 
         return compiled_func

--- a/src/paddlefx/compiler.py
+++ b/src/paddlefx/compiler.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import paddle
-import tvm
-import tvm.testing
-
-from tvm import te
 
 import paddlefx
+
+if TYPE_CHECKING:
+    from tvm import te
 
 
 def paddle_dtype_to_str(dtype: paddle.dtype) -> str:
@@ -57,6 +56,10 @@ class CompilerBase:
 
 class TVMCompiler(CompilerBase):
     def gen_compiled_func(self, symbol_table: dict[str, te.Tensor], dummy_outputs: Any):
+        import tvm
+
+        from tvm import te
+
         tgt = tvm.target.Target(target="llvm", host="llvm")
         schedule = te.create_schedule(symbol_table["output"].op)
         tvm_func = tvm.build(
@@ -85,6 +88,8 @@ class TVMCompiler(CompilerBase):
     def compile_placeholder(
         self, node: paddlefx.Node, symbol_table: dict[str, te.Tensor], inputs: list
     ):
+        from tvm import te
+
         symbol_table[node.name] = te.placeholder(
             inputs[self.input_index].shape,
             paddle_dtype_to_str(inputs[self.input_index].dtype),
@@ -95,6 +100,8 @@ class TVMCompiler(CompilerBase):
     def compile_call_function(
         self, node: paddlefx.Node, symbol_table: dict[str, te.Tensor], inputs: list
     ):
+        from tvm import te
+
         if node.target.__name__ in ["add", "sub", "mul", "div"]:
             left = symbol_table[str(node.args[0])]
             right = symbol_table[str(node.args[1])]

--- a/src/paddlefx/compiler.py
+++ b/src/paddlefx/compiler.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from typing import Callable
 
+import paddle
+import tvm
+import tvm.testing
+
+from tvm import te
+
 import paddlefx
 
 
@@ -9,26 +15,62 @@ class CompilerBase:
     def __init__(self, *, print_tabular: bool = False):
         self.print_tabular = print_tabular
 
-    def __call__(self, gl: paddlefx.GraphLayer, inputs: list | tuple):
+    def __call__(self, gl: paddlefx.GraphLayer, inputs: list):
         if self.print_tabular:
             gl.graph.print_tabular()
         return self.compile(gl, inputs)
 
-    def compile(self, gl: paddlefx.GraphLayer, inputs: list | tuple) -> Callable:
+    def compile(self, gl: paddlefx.GraphLayer, inputs: list) -> Callable:
+        symbol_table = {}
         try:
             for node in gl.graph.nodes:
-                getattr(self, f"compile_{node.op}")(node)
-            return gl.forward  # TODO(zrr1999): return compiled_func
-        except (NotImplementedError, AttributeError):
-            print("AttributeError when compiling graph")
+                getattr(self, f"compile_{node.op}")(node, symbol_table, inputs)
+            return self.gen_compiled_func(symbol_table, inputs)
+        except AttributeError as e:
+            print(f"AttributeError when compiling graph: {e}")
             return gl.forward
 
-    def compile_placeholder(self, node: paddlefx.Node):
-        raise NotImplementedError
-
-    def compile_output(self, node: paddlefx.Node):
-        raise NotImplementedError
+    def gen_compiled_func(self, symbol_table: dict, inputs: list):
+        raise NotImplementedError("CompilerBase is a abstract class")
 
 
-class NumpyCompiler(CompilerBase):
-    pass
+class TVMCompiler(CompilerBase):
+    def gen_compiled_func(self, symbol_table: dict, inputs: list):
+        tgt = tvm.target.Target(target="llvm", host="llvm")
+        s = te.create_schedule(symbol_table["output"].op)
+        tvm_func = tvm.build(s, tuple(symbol_table.values())[:3], tgt, name="myadd")
+
+        def compiled_func(*args):
+            inputs = [tvm.nd.array(arg.numpy()) for arg in args]
+            output = tvm.nd.array(args[0].numpy())
+            tvm_func(*inputs, output)
+            shape = output.shape
+            print(shape)
+            output = paddle.to_tensor(output.asnumpy()).reshape(shape)
+            print(output.shape)
+            return output
+
+        return compiled_func
+
+    def compile_placeholder(
+        self, node: paddlefx.Node, symbol_table: dict, inputs: list
+    ):
+        symbol_table[str(node.name)] = te.placeholder(
+            inputs.pop(0).shape, name=str(node.name)
+        )
+
+    def compile_call_function(
+        self, node: paddlefx.Node, symbol_table: dict, inputs: list
+    ):
+        if node.target.__name__ == "add":
+            left = symbol_table[str(node.args[0])]
+            right = symbol_table[str(node.args[1])]
+            symbol_table[str(node.name)] = te.compute(
+                left.shape, lambda i, j: left[i, j] + right[i, j], name=str(node.name)
+            )
+        else:
+            raise NotImplementedError
+
+    def compile_output(self, node: paddlefx.Node, symbol_table: dict, inputs: list):
+        ret = symbol_table.get(str(node.args[0][0]))
+        symbol_table["output"] = ret

--- a/src/paddlefx/compiler.py
+++ b/src/paddlefx/compiler.py
@@ -28,7 +28,8 @@ def paddle_dtype_to_str(dtype: paddle.dtype) -> str:
 
 
 class CompilerBase:
-    def __init__(self, *, print_tabular: bool = True):
+    def __init__(self, *, full_graph=False, print_tabular: bool = False):
+        self.full_graph = full_graph  # TODO: support full_graph
         self.print_tabular = print_tabular
         self.input_index = 0
 
@@ -116,5 +117,5 @@ class TVMCompiler(CompilerBase):
     def compile_output(
         self, node: paddlefx.Node, symbol_table: dict[str, te.Tensor], inputs: list
     ):
-        ret = symbol_table.get(str(node.args[0][0]))
+        ret = symbol_table[str(node.args[0][0])]
         symbol_table["output"] = ret

--- a/src/paddlefx/eval_frame.py
+++ b/src/paddlefx/eval_frame.py
@@ -45,7 +45,9 @@ def disable(fn=None):
     return DisableContext()(fn)
 
 
-def optimize(backend: Callable = CompilerBase()):
+def optimize(
+    model: Callable | None = None, *, backend: Callable = CompilerBase()
+) -> Callable:
     def _fn(backend: Callable):
         def __fn(frame: types.FrameType):
             try:
@@ -59,4 +61,8 @@ def optimize(backend: Callable = CompilerBase()):
 
         return __fn
 
-    return BaseContext(_fn(backend))
+    ctx = BaseContext(_fn(backend))
+    if model is None:
+        return ctx
+    else:
+        return ctx(model)

--- a/src/paddlefx/legacy_module/translator.py
+++ b/src/paddlefx/legacy_module/translator.py
@@ -9,11 +9,11 @@ from typing import Any
 import paddle
 import paddle.nn
 
-from .bytecode_transformation import Instruction, create_instruction
-from .output_graph import OutputGraph
-from .proxy import Attribute, Proxy
-from .variable_stack import VariableStack
-from .variables.base import VariableBase
+from ..bytecode_transformation import Instruction, create_instruction
+from ..output_graph import OutputGraph
+from ..proxy import Attribute, Proxy
+from ..variable_stack import VariableStack
+from ..variables.base import VariableBase
 
 
 def _binary_constructor(op_name: str):

--- a/src/paddlefx/node.py
+++ b/src/paddlefx/node.py
@@ -22,7 +22,7 @@ class Node:
 
         # Currently, we do not support directly set the args and kwargs of a Node.
         # Please use `_update_args_kwargs` instead.
-        self.args = ()
+        self.args: tuple = ()
         self.kwargs = {}
         self._update_args_kwargs(args, kwargs)
         # Is a dict to act as an "ordered set". Keys are significant, value dont-care

--- a/src/paddlefx/node.py
+++ b/src/paddlefx/node.py
@@ -13,6 +13,7 @@ base_types = BaseArgumentTypes.__args__  # type: ignore[attr-defined]
 # Nodes represent a definition of a value in our graph of operators.
 class Node:
     def __init__(self, graph, name, op, target, args, kwargs):
+        self.meta = {}  # for storing metadata about the node
         self.graph = graph
         self.name = name  # unique name of value being created
         # TODO: whether call_module should be call_layer?

--- a/src/paddlefx/output_graph.py
+++ b/src/paddlefx/output_graph.py
@@ -53,7 +53,10 @@ class OutputGraph:
         gl = GraphLayer(root, self.graph)
 
         compiled_fn_name = f"__compiled_fn_{next(_compiled_fn_counter)}"
-        compiled_fn = self.compiler_fn(gl, None)
+        # TODO: add inputs
+        compiled_fn = self.compiler_fn(
+            gl, [paddle.rand([1, 224]), paddle.rand([1, 224])]
+        )
         log_code(
             compiled_fn.__code__,
             f"COMPILED_FN {compiled_fn_name}",

--- a/src/paddlefx/output_graph.py
+++ b/src/paddlefx/output_graph.py
@@ -12,8 +12,10 @@ from .bytecode_transformation import Instruction, create_instruction
 from .codegen import PyCodegen
 from .graph import Graph
 from .graph_layer import GraphLayer
+from .node import Node
 from .source import LocalSource
 from .utils import format_instruction, log_code, log_instructions
+from .variables.builder import GraphArg
 
 if TYPE_CHECKING:
     from .pyeval import PyEval, PyEvalBase
@@ -38,21 +40,32 @@ class OutputGraph:
         self.root_tx = root_tx
 
         self.graph = Graph()
-        self.graphargs = []
 
         self.should_exit = False
+
+    @property
+    def placeholders(self) -> list[Node]:
+        r = []
+        for node in self.graph.nodes:
+            if node.op == "placeholder":
+                r.append(node)
+                continue
+            break
+        return r
+
+    @property
+    def graphargs(self) -> list[GraphArg]:
+        return [node.meta["grapharg"] for node in self.placeholders]
 
     def add_output_instructions(self, insts: list[Instruction]) -> None:
         self.instructions.extend(insts)
         self.should_exit = True
 
     def example_inputs(self) -> list[paddle.Tensor]:
-        # result = []
-        # for arg in self.graphargs:
-        #     result.extend(arg.get_examples())
-        # return result
-        # TODO: support GraphArg class
-        return [paddle.rand([1, 224]), paddle.rand([1, 224])]
+        result = []
+        for arg in self.graphargs:
+            result.extend(arg.get_examples())
+        return result
 
     def apply_compiler(self, tx: PyEvalBase, rv: list[VariableBase], root):
         from .eval_frame import disable

--- a/src/paddlefx/pyeval.py
+++ b/src/paddlefx/pyeval.py
@@ -194,8 +194,8 @@ class PyEvalBase:
             if self.checkpoint is None:
                 raise
             logging.debug(f"!! NotImplementedError: {e}")
-        except Exception:
-            raise
+        except Exception as e:
+            raise e
 
         # fallback
         logging.debug(f"graph break from instruction: \n{format_instruction(inst)}")

--- a/src/paddlefx/pyeval.py
+++ b/src/paddlefx/pyeval.py
@@ -379,15 +379,9 @@ class PyEvalBase:
     # def BUILD_SET(self, inst: Instruction):
     # def BUILD_MAP(self, inst: Instruction):
     def LOAD_ATTR(self, inst: Instruction):
-        fn = getattr
-
+        # TODO: use AttributeVariable
         owner = self.stack.pop()
-        self.call_function(
-            CallableVariable(fn, tx=self),
-            [owner, VariableBase(var=inst.argval)],
-            {},
-            count_call=False,
-        )
+        self.stack.push(CallableVariable(getattr(owner.var, inst.argval), tx=self))
 
     def COMPARE_OP(self, inst: Instruction):
         comparison_ops = {

--- a/src/paddlefx/pyeval.py
+++ b/src/paddlefx/pyeval.py
@@ -657,7 +657,6 @@ class PyEval(PyEvalBase):
             if k in frame.f_locals:
                 value = frame.f_locals[k]
                 # TODO: implement VariableFactory
-                print(value, type(value))
                 if isinstance(value, (types.FunctionType)):
                     self.symbolic_locals[k] = CallableVariable(
                         fn=value,

--- a/src/paddlefx/pyeval.py
+++ b/src/paddlefx/pyeval.py
@@ -29,6 +29,7 @@ from .utils import format_instruction, log_code
 from .variable_stack import VariableStack
 from .variables import CallableVariable, TupleVariable, VariableBase
 from .variables.base import TensorVariable
+from .variables.builder import GraphArg
 
 if TYPE_CHECKING:
     # import opcode
@@ -689,7 +690,8 @@ class PyEval(PyEvalBase):
                 and not var.source.local_name.startswith("___stack")
                 and var.source.local_name not in ['self']
             ):
-                self.output.graph.placeholder(var.source.local_name)
+                node = self.output.graph.placeholder(var.source.local_name)
+                node.meta["grapharg"] = GraphArg(example=var.var)
 
     def create_call_resume_at(self, inst: Instruction | None) -> list[Instruction]:
         assert inst is not None

--- a/src/paddlefx/utils.py
+++ b/src/paddlefx/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dis
 import logging
+import traceback
 import types
 
 from typing import TYPE_CHECKING
@@ -54,3 +55,32 @@ def hashable(obj) -> bool:
         return True
     except TypeError as e:
         return False
+
+
+class InnerErrorBase(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # TODO: add BreakpointManager
+
+    def print(self):
+        lines = traceback.format_tb(self.__traceback__)
+        print("".join(lines))
+
+
+class InnerError(InnerErrorBase):
+    pass
+
+
+class HasNoAttributeError(InnerError):
+    pass
+
+
+class FallbackError(InnerErrorBase):
+    def __init__(self, msg, disable_eval_frame=False):
+        super().__init__(msg)
+        self.disable_eval_frame = False
+
+
+# raise in inline function call strategy.
+class BreakGraphError(InnerErrorBase):
+    pass

--- a/src/paddlefx/variables/builder.py
+++ b/src/paddlefx/variables/builder.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import dataclasses
+
+from typing import Any
+
+
+@dataclasses.dataclass
+class GraphArg:
+    example: Any
+    is_tensor: bool = True
+
+    def get_examples(self):
+        return [self.example]
+
+    def __len__(self):
+        return 1

--- a/src/paddlefx/variables/callable.py
+++ b/src/paddlefx/variables/callable.py
@@ -79,7 +79,7 @@ class CallableVariable(VariableBase):
             ot = type(args[0].var)
             obj_cls = type(args[0])
             output = graph.call_function(fn, args, kwargs, ot)
-            return obj_cls(node=output)
+            return TensorVariable(None, node=output)
         elif inspect.isbuiltin(fn):
             if fn is print:
                 raise NotImplementedError("print() is not supported")

--- a/src/paddlefx/variables/callable.py
+++ b/src/paddlefx/variables/callable.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable
 import paddle
 
 from ..source import Source
+from ..utils import BreakGraphError
 from .base import ObjectVariable, TensorVariable, VariableBase
 
 if TYPE_CHECKING:
@@ -58,7 +59,9 @@ class CallableVariable(VariableBase):
             elif not fn.__module__.startswith('paddle.nn'):
                 globals()['self'] = tx.f_locals['self']
                 result = tx.inline_call_function(
-                    CallableVariable(fn=fn.forward.__func__), (self, *args), kwargs
+                    CallableVariable(fn=fn.forward.__func__, tx=tx),
+                    (self, *args),
+                    kwargs,
                 )
                 del globals()['self']
                 return result
@@ -82,7 +85,7 @@ class CallableVariable(VariableBase):
             return TensorVariable(None, node=output)
         elif inspect.isbuiltin(fn):
             if fn is print:
-                raise NotImplementedError("print() is not supported")
+                raise BreakGraphError("print is triggered")
             elif fn is getattr:
                 object, name = args
                 attr = getattr(object.var, name.var)
@@ -91,10 +94,10 @@ class CallableVariable(VariableBase):
                         # For method variables
                         ot = type(args[0].var)
                         obj_cls = type(args[0])
-                        return CallableVariable(fn=attr)
+                        return CallableVariable(fn, tx=tx)
                     else:
                         # the attr could be callable function
-                        return CallableVariable(fn=attr)
+                        return CallableVariable(fn, tx=tx)
                 else:
                     return VariableBase(var=attr)
             elif fn in [

--- a/src/paddlefx/variables/callable.py
+++ b/src/paddlefx/variables/callable.py
@@ -36,13 +36,13 @@ class CallableVariable(VariableBase):
                 name = repr(self.var)
         return f"{self.__class__.__name__}({name})"
 
-    def __call__(self, tx: PyEvalBase, *args: VariableBase, **kwargs) -> Any:
+    def __call__(self, tx: PyEvalBase, *args: VariableBase, **kwargs) -> VariableBase:
         # TODO: better org
         fn = self.var
         graph = tx.output.graph
 
         # nn.layer
-        if isinstance(fn, paddle.nn.Layer):
+        if isinstance(fn, paddle.nn.Layer):  # type: ignore
             # unroll nn.Sequential
             if 'container' in fn.__module__:
                 assert not kwargs

--- a/src/paddlefx/variables/callable.py
+++ b/src/paddlefx/variables/callable.py
@@ -97,7 +97,13 @@ class CallableVariable(VariableBase):
                         return CallableVariable(fn=attr)
                 else:
                     return VariableBase(var=attr)
-            elif fn in [operator.add, operator.sub, operator.iadd]:
+            elif fn in [
+                operator.add,
+                operator.sub,
+                operator.mul,
+                operator.truediv,
+                operator.iadd,
+            ]:
                 ot = type(args[0].var)
                 obj_cls = type(args[0])
                 output = graph.call_function(fn, args, kwargs, ot)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,6 +8,8 @@ import paddlefx
 
 from paddlefx.compiler import TVMCompiler
 
+paddle.seed(0)
+
 
 def add(x, y):
     z = x + y

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -27,6 +27,7 @@ def func_add(a, b):
 
 
 def test_add():
+    # NOTE: now only support 1x224 tensor
     in_a = paddle.rand([1, 224])
     in_b = paddle.rand([1, 224])
     np.testing.assert_allclose(add(in_a, in_b), in_a + in_b)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -34,6 +34,6 @@ def test_add():
 
 
 def test_func_add():
-    in_a = paddle.rand([1, 224])
-    in_b = paddle.rand([1, 224])
+    in_a = paddle.rand([128, 224])
+    in_b = paddle.rand([128, 224])
     np.testing.assert_allclose(func_add(in_a, in_b), in_a + in_b)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,8 +6,6 @@ import paddle.nn
 
 import paddlefx
 
-from paddlefx.compiler import TVMCompiler
-
 paddle.seed(0)
 
 
@@ -29,7 +27,7 @@ def func(a, b):
 
 
 def check_func(func, *args):
-    comiled_func = paddlefx.optimize(func, backend=TVMCompiler(print_tabular=True))
+    comiled_func = paddlefx.optimize(func)
     out = func(*args)
     res = comiled_func(*args)
     np.testing.assert_allclose(res, out)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,8 +6,10 @@ import paddle.nn
 
 import paddlefx
 
+from paddlefx.compiler import TVMCompiler
 
-@paddlefx.optimize()
+
+@paddlefx.optimize(backend=TVMCompiler())
 def add(x, y):
     z = x + y
     return z
@@ -18,19 +20,19 @@ def func(x, y):
     return z
 
 
-@paddlefx.optimize()
+@paddlefx.optimize(backend=TVMCompiler())
 def func_add(a, b):
     d = func(a, b)
     return d
 
 
 def test_add():
-    in_a = paddle.rand([1])
-    in_b = paddle.rand([1])
+    in_a = paddle.rand([1, 224])
+    in_b = paddle.rand([1, 224])
     np.testing.assert_allclose(add(in_a, in_b), in_a + in_b)
 
 
 def test_func_add():
-    in_a = paddle.rand([1])
-    in_b = paddle.rand([1])
+    in_a = paddle.rand([1, 224])
+    in_b = paddle.rand([1, 224])
     np.testing.assert_allclose(func_add(in_a, in_b), in_a + in_b)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -15,9 +15,9 @@ def add(x, y):
 
 
 def inner_func(x, y):
-    p = x + y
-    q = x - y
-    z = p * x
+    p = paddle.add(x, y)
+    q = paddle._C_ops.subtract(x, y)
+    z = p * q
     return z / y
 
 

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import numpy as np
+import paddle
+import paddle.nn
+
+import paddlefx
+
+from paddlefx.compiler import TVMCompiler
+
+
+def add(x, y):
+    z = x + y
+    return z
+
+
+def check_func(func, *args):
+    comiled_func = paddlefx.optimize(func, backend=TVMCompiler(print_tabular=True))
+    out = func(*args)
+    res = comiled_func(*args)
+    np.testing.assert_allclose(res, out)
+
+
+def test_broadcast_add():
+    in_a = paddle.rand([224, 224])
+    in_b = paddle.rand([1, 224])
+    check_func(add, in_a, in_b)


### PR DESCRIPTION
经过一段时间的尝试，最后选择 TVM 作为第一个计划支持的后端

选择 TVM 的理由
1. 安装简单（与 mlir 等相比）
2. 使用 FX 图构建 TVM 的网络相对简单（与triton、tensorRT等相比）
3. 速度较快

目前实现的进度
1. 完成 add 算子的基本流程。
2. 支持加减乘除等大部分简单运算。
3. ~~支持尺寸相同的原子操作~~
4. ~~支持基本的广播~~
5. 支持Paddle里的四则运算算子，例如target3中的。
6. 四则运算采用topi实现，从而不需要手写 fcompute 。

实现的功能
- [x] 目前的 example_inputs 是直接输出固定的 tensor。后续需要继续实现 example_inputs 
- [x] 实现GraphArg。
