### PR TITLE
Use loguru and appdirs to replace logging and hard coded path

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,8 +1,6 @@
 # ------------------------------------------------
 # Options affecting comment reflow and formatting.
 # ------------------------------------------------
-from __future__ import annotations
-
 with section("markup"):
     # enable comment markup parsing and reflow
     enable_markup = False

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.291
+    rev: v0.0.292
     hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix, --no-cache]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
     hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix, --no-cache]
-      exclude: .cmake-format.py
   - repo: https://github.com/asottile/yesqa
     rev: v1.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,6 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.1
-    hooks:
-      - id: autoflake
-        args:
-          - "--in-place"
-          - "--jobs"
-          - "10"
-          - "--expand-star-imports"
-          - "--remove-duplicate-keys"
-          # - "--remove-unused-variables"
-          - "--remove-all-unused-imports"
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.291
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
           # - "--remove-unused-variables"
           - "--remove-all-unused-imports"
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.254
+    rev: v0.0.291
     hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix, --no-cache]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,18 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.0.1
+    hooks:
+      - id: autoflake
+        args:
+          - "--in-place"
+          - "--jobs"
+          - "10"
+          - "--expand-star-imports"
+          - "--remove-duplicate-keys"
+          # - "--remove-unused-variables"
+          - "--remove-all-unused-imports"
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.292
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,10 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
+    hooks:
+      - id: black
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.0.1
     hooks:
@@ -25,8 +29,8 @@ repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.292
     hooks:
-    - id: ruff
-      args: [--fix, --exit-non-zero-on-fix, --no-cache]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix, --no-cache]
   - repo: https://github.com/asottile/yesqa
     rev: v1.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix, --no-cache]
+      exclude: .cmake-format.py
   - repo: https://github.com/asottile/yesqa
     rev: v1.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,14 +10,6 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-      - id: black
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.0.1
     hooks:

--- a/examples/native_interpreter/pyproject.toml
+++ b/examples/native_interpreter/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff.isort]
+lines-between-types = 1
+known-first-party = ["build"]

--- a/examples/native_interpreter/use_interpreter.py
+++ b/examples/native_interpreter/use_interpreter.py
@@ -21,8 +21,8 @@ print(f">> python IR for {net.__name__}")
 traced_layer.graph.print_tabular()
 
 # the very simple IR we want to lower fx graph to
-# each instruction is a list of string of:  operation, left_operand, right_operand, result
-# only two op supported: add, mul
+# each instruction is a list of string of:  operation, left_operand,
+# right_operand, result only two op supported: add, mul
 input_names = []
 instructions = []
 

--- a/examples/native_interpreter/use_interpreter.py
+++ b/examples/native_interpreter/use_interpreter.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import paddle
 
-from build import myinterpreter
-
 import paddlefx
 
+from build import myinterpreter
 from paddlefx import symbolic_trace
 
 

--- a/examples/resnet_dynamo.py
+++ b/examples/resnet_dynamo.py
@@ -12,7 +12,7 @@ import paddlefx
 from paddlefx.compiler.tvm import TVMCompiler
 
 paddle.seed(1234)
-# logging.getLogger().setLevel(logging.DEBUG)
+
 
 compiler = TVMCompiler(
     full_graph=True,

--- a/examples/simple_compiler.py
+++ b/examples/simple_compiler.py
@@ -11,7 +11,7 @@ from paddlefx.compiler import TVMCompiler
 
 paddle.seed(1234)
 
-# logging.getLogger().setLevel(logging.DEBUG)
+
 
 
 def inner_func(x, y):

--- a/examples/simple_compiler.py
+++ b/examples/simple_compiler.py
@@ -12,8 +12,6 @@ from paddlefx.compiler import TVMCompiler
 paddle.seed(1234)
 
 
-
-
 def inner_func(x, y):
     p = paddle.add(x, y)
     # q = paddle._C_ops.subtract(x, y)  # static unsupported

--- a/examples/simple_dynamo.py
+++ b/examples/simple_dynamo.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 import numpy as np
 import paddle
 import paddle.nn
@@ -10,7 +8,6 @@ import paddlefx
 
 from paddlefx.compiler import DummyCompiler, TVMCompiler
 
-logging.getLogger().setLevel(logging.DEBUG)
 static_compier = DummyCompiler(full_graph=True, print_tabular_mode="rich")
 compiler = TVMCompiler(full_graph=True, print_tabular_mode="rich")
 

--- a/examples/targets/target_0_add.py
+++ b/examples/targets/target_0_add.py
@@ -11,8 +11,6 @@ import paddle.nn
 
 import paddlefx
 
-logging.basicConfig(level=logging.DEBUG, format="%(message)s")
-
 
 def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = None):
     print("my_compiler() called with FX graph:")

--- a/examples/targets/target_1_print.py
+++ b/examples/targets/target_1_print.py
@@ -11,8 +11,6 @@ import paddle.nn
 
 import paddlefx
 
-logging.basicConfig(level=logging.DEBUG, format="%(message)s")
-
 # TODO: support grpah break for `print`
 
 

--- a/examples/targets/target_2_func.py
+++ b/examples/targets/target_2_func.py
@@ -1,19 +1,10 @@
 from __future__ import annotations
 
-import logging
-
-# ignore DeprecationWarning from `pkg_resources`
-logging.captureWarnings(True)
-
-
 import paddle
 import paddle.nn
 
 import paddlefx
 import paddlefx.utils
-
-# logging.basicConfig(level=logging.DEBUG, format="%(message)s")
-logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 
 def my_compiler(gl: paddlefx.GraphLayer, example_inputs: list[paddle.Tensor] = None):

--- a/examples/targets/target_3_add_paddle.py
+++ b/examples/targets/target_3_add_paddle.py
@@ -1,21 +1,11 @@
 from __future__ import annotations
 
-import logging
-
-# ignore DeprecationWarning from `pkg_resources`
-logging.captureWarnings(True)
-
 import paddle
 import paddle._C_ops
 
 import paddlefx
 
 from paddlefx.compiler import TVMCompiler
-
-logging.basicConfig(level=logging.DEBUG, format="%(message)s")
-# logging.basicConfig(level=logging.INFO, format="%(message)s")
-
-paddle.seed(1234)
 
 
 def func(x, y):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 select = [
     "UP",
+    "F",
     "I"
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,26 +9,22 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
-skip-string-normalization = true
-# default value may too big to run
-workers = 4
-
-# https://pycqa.github.io/isort/docs/configuration/options.html
-[tool.isort]
-profile = "black"
-lines_between_types = 1
-known_first_party = ["paddlefx"]
-add_imports = ["from __future__ import annotations"]
-
 # https://beta.ruff.rs/docs/configuration/
 [tool.ruff]
 select = [
     "UP",
     "I"
 ]
-ignore = ["UP015"]
+ignore = [
+    "UP015",
+    "Q000"
+]
 target-version = "py38"
+
+[tool.ruff.isort]
+lines-between-types = 1
+known-first-party = ["paddlefx"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.pytest.ini_options]
 minversion = "7.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ select = [
 ]
 ignore = [
     "UP015",
-    "Q000"
+    "Q000",
+    "F405"
 ]
 target-version = "py38"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,10 @@ add_imports = ["from __future__ import annotations"]
 
 # https://beta.ruff.rs/docs/configuration/
 [tool.ruff]
-select = ["UP"]
+select = [
+    "UP",
+    "I"
+]
 ignore = ["UP015"]
 target-version = "py38"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ build-backend = "setuptools.build_meta"
 
 # https://beta.ruff.rs/docs/configuration/
 [tool.ruff]
+exclude = [".cmake-format.py"]
 select = [
     "UP",
     "F",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.black]
+skip-string-normalization = true
+# default value may too big to run
+workers = 4
+
 # https://beta.ruff.rs/docs/configuration/
 [tool.ruff]
 exclude = [".cmake-format.py"]
@@ -19,7 +24,6 @@ select = [
 ]
 ignore = [
     "UP015",
-    "Q000",
     "F405"
 ]
 target-version = "py38"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 paddlepaddle>=2.4.0
 pydot
 loguru
+appdirs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 paddlepaddle>=2.4.0
 pydot
+loguru

--- a/src/paddlefx/cache_manager.py
+++ b/src/paddlefx/cache_manager.py
@@ -5,6 +5,8 @@ import types
 
 from typing import TYPE_CHECKING, Callable
 
+from loguru import logger
+
 if TYPE_CHECKING:
     GuardFunction = Callable[[types.FrameType], bool]
     GuardedCodes = list["GuardedCode"]
@@ -28,7 +30,7 @@ class CodeCacheManager:
     def get_cache(cls, frame: types.FrameType) -> GuardedCode | None:
         code: types.CodeType = frame.f_code
         if code not in cls.cache_dict:
-            print(f"Firstly call {code}\n")
+            logger.success(f"Firstly call {code}\n")
             return None
         return cls.lookup(frame, cls.cache_dict[code])
 
@@ -44,17 +46,17 @@ class CodeCacheManager:
             try:
                 guard_fn = guarded_code.guard_fn
                 if guard_fn(frame):
-                    print(
+                    logger.success(
                         f"[Cache]: Cache hit, GuardFunction is {guard_fn}\n",
                     )
                     return guarded_code
                 else:
-                    print(
+                    logger.info(
                         f"[Cache]: Cache miss, GuardFunction is {guard_fn}\n",
                     )
             except Exception as e:
-                print(f"[Cache]: GuardFunction function error: {e}\n")
+                logger.exception(f"[Cache]: GuardFunction function error: {e}\n")
                 continue
 
-        print("[Cache]: all guards missed\n")
+        logger.success("[Cache]: all guards missed\n")
         return None

--- a/src/paddlefx/compiler/tvm.py
+++ b/src/paddlefx/compiler/tvm.py
@@ -6,6 +6,7 @@ import paddle
 import paddle.device
 import tvm
 
+from appdirs import user_cache_dir
 from loguru import logger
 from tvm import auto_scheduler, relay
 
@@ -44,7 +45,7 @@ class TVMCompiler(CompilerBase):
                 self.input_index += 1
         static_func = paddle.jit.to_static(gl.forward)
         static_func(*example_inputs)
-        model_path = f"~/.cache/paddlefx/model_{id(gl)}"
+        model_path = f"{user_cache_dir('paddlefx')}/paddle_static_model/{id(gl)}"
         paddle.jit.save(static_func, model_path)
         translated_layer = paddle.jit.load(model_path)
         mod, params = relay.frontend.from_paddle(translated_layer)

--- a/src/paddlefx/compiler/tvm.py
+++ b/src/paddlefx/compiler/tvm.py
@@ -6,6 +6,7 @@ import paddle
 import paddle.device
 import tvm
 
+from loguru import logger
 from tvm import auto_scheduler, relay
 
 import paddlefx
@@ -53,11 +54,10 @@ class TVMCompiler(CompilerBase):
             )
 
             for idx, task in enumerate(tasks):
-                print(
-                    "========== Task %d  (workload key: %s) =========="
-                    % (idx, task.workload_key)
+                logger.info(
+                    f"========== Task {idx}  (workload key: {task.workload_key}) =========="
                 )
-                print(task.compute_dag)
+                logger.info(task.compute_dag)
 
             tuner = auto_scheduler.TaskScheduler(tasks, task_weights)
             tune_option = auto_scheduler.TuningOptions(

--- a/src/paddlefx/convert_frame.py
+++ b/src/paddlefx/convert_frame.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import logging
 import types
 
 from typing import TYPE_CHECKING, Callable
+
+from loguru import logger
 
 from .bytecode_transformation import Instruction, transform_code_object
 from .cache_manager import CodeCacheManager, GuardedCode
@@ -31,7 +32,7 @@ def skip_frame(frame: types.FrameType) -> bool:
 
 def convert_frame(frame: types.FrameType, compiler_fn: Callable) -> GuardedCode | None:
     if skip_frame(frame):
-        logging.debug(f"skip_frame: {frame}")
+        logger.debug(f"skip_frame: {frame}")
         return None
     # TODO: guard_fn is not declared in this scope
     guard_fn = None
@@ -45,12 +46,12 @@ def convert_frame(frame: types.FrameType, compiler_fn: Callable) -> GuardedCode 
         code_options.update(tracer.output.code_options)
         instructions[:] = tracer.output.instructions
 
-    logging.info(f"convert_frame: {frame}")
+    logger.info(f"convert_frame: {frame}")
     code = frame.f_code
     log_code(code, "ORIGINAL_BYTECODE")
 
     if (cached_code := CodeCacheManager.get_cache(frame)) is not None:
-        logging.info(f"cached_code: {cached_code}")
+        logger.info(f"cached_code: {cached_code}")
         return cached_code
 
     # TODO: rm torch code dependency

--- a/src/paddlefx/eval_frame.py
+++ b/src/paddlefx/eval_frame.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import functools
-import logging
 import types
 
 from typing import Callable
+
+from loguru import logger
 
 from ._eval_frame import set_eval_frame
 from .compiler import DummyCompiler
@@ -54,7 +55,7 @@ def optimize(
                 guarded_code = convert_frame(frame, backend)
                 return guarded_code
             except NotImplementedError as e:
-                logging.debug(f"!! NotImplementedError: {e}")
+                logger.debug(f"!! NotImplementedError: {e}")
             except Exception:
                 raise
             return None

--- a/src/paddlefx/legacy_module/translator.py
+++ b/src/paddlefx/legacy_module/translator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import operator
 import types
 
@@ -8,6 +7,8 @@ from typing import Any
 
 import paddle
 import paddle.nn
+
+from loguru import logger
 
 from ..bytecode_transformation import Instruction, create_instruction
 from ..output_graph import OutputGraph
@@ -323,7 +324,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         if not hasattr(self, inst.opname):
             raise NotImplementedError(f"missing: {inst.opname}")
 
-        logging.debug(f"TRACE {inst.opname} {inst.argval} {self.stack}")
+        logger.debug(f"TRACE {inst.opname} {inst.argval} {self.stack}")
         getattr(self, inst.opname)(inst)
 
     def run(self):

--- a/src/paddlefx/legacy_module/translator.py
+++ b/src/paddlefx/legacy_module/translator.py
@@ -128,7 +128,7 @@ class InstructionTranslatorBase:
             res = self.output.create_node('call_function', fn, args, kwargs)
             self.stack.push(res)
         elif is_custom_call:
-            raise NotImplementedError(f"custom_call is not supported")
+            raise NotImplementedError("custom_call is not supported")
         else:
             raise NotImplementedError(f"call function {fn} is not supported")
 
@@ -237,7 +237,7 @@ class InstructionTranslatorBase:
         self.output.create_node('call_method', "__setitem__", [root, idx, value], {})
 
     def POP_TOP(self, inst: Instruction):
-        value = self.stack.pop()
+        self.stack.pop()
 
     def STORE_FAST(self, inst: Instruction):
         self.f_locals[inst.argval] = self.stack.pop()

--- a/src/paddlefx/output_graph.py
+++ b/src/paddlefx/output_graph.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import itertools
-import logging
 import types
 
 from typing import TYPE_CHECKING, Callable, OrderedDict
 
 import paddle
+
+from loguru import logger
 
 from .bytecode_transformation import Instruction, create_instruction
 from .codegen import PyCodegen
@@ -109,7 +110,7 @@ class OutputGraph:
         log_code(
             compiled_fn.__code__,
             f"COMPILED_FN {compiled_fn_name}",
-            log_fn=logging.debug,
+            log_fn=logger.debug,
         )
         compiled_fn = disable(compiled_fn)
         tx.f_globals[compiled_fn_name] = compiled_fn
@@ -120,7 +121,7 @@ class OutputGraph:
         return cg.instructions
 
     def compile_subgraph(self, tx: PyEvalBase):
-        logging.debug(
+        logger.debug(
             f"start compile_subgraph, current_instruction: \n{format_instruction(tx.current_instruction)}"  # type: ignore
         )
         tx.prune_dead_locals()
@@ -164,4 +165,4 @@ class OutputGraph:
         self.add_output_instructions(
             [PyCodegen(tx).create_store(var) for var in reversed(restore_vars)]
         )
-        log_instructions(self.instructions, 'COMPILE_SUBGRAPH', log_fn=logging.debug)
+        log_instructions(self.instructions, 'COMPILE_SUBGRAPH', log_fn=logger.debug)

--- a/src/paddlefx/pyeval.py
+++ b/src/paddlefx/pyeval.py
@@ -62,10 +62,10 @@ def break_graph_if_unsupported(*, push: int):
             state = self.get_state()
             try:
                 return inner_fn(self, inst)
-            except (BreakGraphError, NotImplementedError) as e:
+            except (BreakGraphError, NotImplementedError):
                 # TODO: remove NotImplementedError
                 logger.debug(
-                    f"break_graph_if_unsupported triggered compile", exc_info=True
+                    "break_graph_if_unsupported triggered compile", exc_info=True
                 )
 
                 if not isinstance(self, PyEval):

--- a/src/paddlefx/utils.py
+++ b/src/paddlefx/utils.py
@@ -61,7 +61,7 @@ def hashable(obj) -> bool:
     try:
         hash(obj)
         return True
-    except TypeError as e:
+    except TypeError:
         return False
 
 

--- a/src/paddlefx/utils.py
+++ b/src/paddlefx/utils.py
@@ -14,9 +14,7 @@ if TYPE_CHECKING:
     from .bytecode_transformation import Instruction
 
 logger.remove()
-logger.add(
-    sys.stdout, level=os.environ.get("LOG_LEVEL", "INFO")
-)
+logger.add(sys.stdout, level=os.environ.get("LOG_LEVEL", "INFO"))
 
 
 def format_bytecode(prefix, name, filename, line_no, code):

--- a/src/paddlefx/utils.py
+++ b/src/paddlefx/utils.py
@@ -1,25 +1,33 @@
 from __future__ import annotations
 
 import dis
-import logging
+import os
+import sys
 import traceback
 import types
 
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 if TYPE_CHECKING:
     from .bytecode_transformation import Instruction
+
+logger.remove()
+logger.add(
+    sys.stdout, level=os.environ.get("LOG_LEVEL", "INFO")
+)
 
 
 def format_bytecode(prefix, name, filename, line_no, code):
     return f"{prefix} {name} {filename} line {line_no} \n{dis.Bytecode(code).dis()}"
 
 
-def log_bytecode(prefix, name, filename, line_no, code, log_fn=logging.info):
+def log_bytecode(prefix, name, filename, line_no, code, log_fn=logger.info):
     log_fn(format_bytecode(prefix, name, filename, line_no, code))
 
 
-def log_code(code: types.CodeType, prefix='', log_fn=logging.info):
+def log_code(code: types.CodeType, prefix='', log_fn=logger.info):
     log_bytecode(
         prefix, code.co_name, code.co_filename, code.co_firstlineno, code, log_fn=log_fn
     )
@@ -38,7 +46,7 @@ def format_instruction(inst: dis.Instruction | Instruction):
 def log_instructions(
     instructions: list[dis.Instruction] | list[Instruction],
     prefix='',
-    log_fn=logging.info,
+    log_fn=logger.info,
 ):
     log_fn(f"{prefix}")
     for inst in instructions:

--- a/src/paddlefx/variables/callable.py
+++ b/src/paddlefx/variables/callable.py
@@ -67,7 +67,7 @@ class CallableVariable(VariableBase):
                 return result
             else:  # basic layer
                 ot = type(args[0].var)
-                obj_cls = type(args[0])
+
                 target = ''
                 model = (
                     tx.f_locals['self'] if 'self' in tx.f_locals else globals()['self']
@@ -82,7 +82,7 @@ class CallableVariable(VariableBase):
         elif fn.__module__.startswith("paddle"):
             # TODO: support multiple ouputs and containers
             ot = type(args[0].var)
-            obj_cls = type(args[0])
+
             output = graph.call_function(fn, args, kwargs, ot)
             return TensorVariable(None, node=output)
         elif inspect.isbuiltin(fn):
@@ -95,7 +95,7 @@ class CallableVariable(VariableBase):
                     if isinstance(attr, types.MethodType):
                         # For method variables
                         ot = type(args[0].var)
-                        obj_cls = type(args[0])
+
                         return CallableVariable(fn, tx=tx)
                     else:
                         # the attr could be callable function
@@ -110,17 +110,17 @@ class CallableVariable(VariableBase):
                 operator.iadd,
             ]:
                 ot = type(args[0].var)
-                obj_cls = type(args[0])
+
                 output = graph.call_function(fn, args, kwargs, ot)
                 return TensorVariable(None, node=output)
             elif fn in [operator.gt, operator.lt, operator.ge, operator.le]:
                 ot = type(args[0].var)
-                obj_cls = type(args[0])
+
                 output = graph.call_function(fn, args, kwargs, ot)
                 return TensorVariable(None, node=output)
             elif fn in [operator.is_, operator.is_not]:
                 ot = type(args[0].var)
-                obj_cls = type(args[0])
+
                 output = graph.call_function(fn, args, kwargs, ot)
                 return TensorVariable(None, node=output)
             else:


### PR DESCRIPTION
1. 使用 loguru 代替 logging，并将compiler中的print替换为日志形式。
2. 使用 appdirs 获取缓存路径，避免为每个系统单独寻找缓存路径。
3. 移除 isort 并在 ruff 中加入相应替代配置。